### PR TITLE
Focus camera on newly mounted scenes

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1087,7 +1087,7 @@ program
 program
   .command("mount")
   .description(
-    `Compile a Solid JSX project module and mount its roots into the canvas. Re-mounting reconciles rather than duplicates: each top-level element carries a \`key\`, and a root replaces the node with that key or creates it (a new <scene key> becomes the active scene). Long-running when the module declares AI assets (blocks until generation finishes). Compile errors fail before the app is contacted; on success, inspect the result with \`dapi context\` or \`dapi node tree\`.`,
+    `Compile a Solid JSX project module and mount its roots into the canvas. Re-mounting reconciles rather than duplicates: each top-level element carries a \`key\`, and a root replaces the node with that key or creates it (a new <scene key> becomes the active scene and the camera focuses it). Long-running when the module declares AI assets (blocks until generation finishes). Compile errors fail before the app is contacted; on success, inspect the result with \`dapi context\` or \`dapi node tree\`.`,
   )
   .argument("[path]", "path to a .tsx / .jsx / .ts / .js entry module")
   .option("--code <str>", "inline module source; export default wrapper optional for bare JSX")

--- a/apps/web/src/context/editor-api/mount.ts
+++ b/apps/web/src/context/editor-api/mount.ts
@@ -50,6 +50,7 @@ export function handleMount(engine: Accessor<Engine>) {
 
       if (document.rootEid && hasComponent(world, document.rootEid, c.Scene)) {
         switchActiveScene(world, document.rootEid);
+        if (document.rootCreated) e.camera.fitToActiveScene();
       }
     } catch (error) {
       return { status: "rejected", error: error instanceof Error ? error.message : String(error) };

--- a/apps/web/src/utils/jsx.ts
+++ b/apps/web/src/utils/jsx.ts
@@ -199,6 +199,8 @@ export class WorldDocument implements ProjectDocument<DocumentNode> {
   public promises: Promise<void>[] = [];
   public stage: DocumentNode;
   public rootEid: number | null = null;
+  /** Whether the root was created fresh rather than reconciled onto an existing keyed node. */
+  public rootCreated = false;
   public engine: Engine;
 
   private queue: GenaiQueueItem[] = [];
@@ -821,6 +823,8 @@ export class WorldDocument implements ProjectDocument<DocumentNode> {
         // Find and replace node with the same key
         const existing = query(this.world, [c.Key, Not(c.Deleted)])
           .find((eid) => eid !== node.eid && c.Key[eid] === key);
+
+        this.rootCreated = existing === undefined;
 
         if (existing === undefined) {
           const width = c.Computed.width[node.eid] ?? 0;


### PR DESCRIPTION
## What

When `dapi mount` creates a new scene root (a `<scene key>` that has no existing node with the same key), the camera now fits the scene into view after it becomes the active scene.

## Why

Mounting a new scene already switched the active scene, but the viewport stayed wherever it was, so the freshly mounted scene could land off-screen. Now it is brought into view immediately.

## How

- `WorldDocument` tracks a new `rootCreated` flag, set during root insertion based on whether an existing node with the same key was found (created fresh) or reconciled onto.
- The mount handler calls `camera.fitToActiveScene()` after `switchActiveScene`, but only when `rootCreated` is true.
- The `dapi mount` command description mentions the new behavior.

## Notes for review

- Camera focus is deliberately conditional on the scene being **new**: re-mounting an existing key still switches the active scene (unchanged behavior) but leaves the camera alone, so iterating on a project while zoomed into a detail does not yank the viewport on every mount.
- `fitToActiveScene()` works synchronously at commit time because `Position` (from `findPlacement`) and `Computed` width/height (from `resizeEntity`) are already populated when the root is inserted.
- `apps/web` typechecks clean (`npm run check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)