### PR TITLE
fix: accept ElectronFileHandle in sidebar asset imports

### DIFF
--- a/apps/web/src/components/sidebar-left/assets.tsx
+++ b/apps/web/src/components/sidebar-left/assets.tsx
@@ -43,6 +43,7 @@ import { LazyAssetItem } from "./asset-item";
 import { FolderItem, handleFolderDrop, ASSET_DRAG_TYPE, FOLDER_DRAG_TYPE } from "./folder-item";
 
 import type { EngineWorld } from "@/components/engine";
+import type { ElectronFileHandle } from "@/lib/electron-file-handle";
 
 export function Assets() {
   let root: HTMLDivElement | undefined;
@@ -122,7 +123,9 @@ export function Assets() {
     }
   });
 
-  const importAssets = async (handles: ReadonlyArray<File | FileSystemFileHandle | DataTransferItem>) => {
+  const importAssets = async (
+    handles: ReadonlyArray<File | FileSystemFileHandle | ElectronFileHandle | DataTransferItem>,
+  ) => {
     if (handles.length === 0) return;
 
     try {


### PR DESCRIPTION
## Summary

`showFileDialog()` can return `ElectronFileHandle` in desktop builds, but the sidebar `importAssets` helper omitted it from its parameter union — breaking the desktop web build (`tsc -b`) on `main`. Each handle is forwarded to `loadAsset()`, which already accepts `ElectronFileHandle`, so this is a type-surface fix only, no runtime change.

## Error

```
src/components/sidebar-left/assets.tsx(141,24): error TS2345:
  'ElectronFileHandle' is not assignable to
  'File | FileSystemFileHandle | DataTransferItem'.
```

## Fix

`apps/web/src/components/sidebar-left/assets.tsx` — import `ElectronFileHandle` (type) and add it to the `importAssets` handles union.

## Validation

- `tsc -b` — pass
- `npm run build:desktop` — pass
- `SKIP_SIGN=1 npm run make` (DMG) — pass

Base branch: `main`
