### PR TITLE
Bump Homebrew cask on release publish

### DIFF
--- a/.github/workflows/bump-cask.yml
+++ b/.github/workflows/bump-cask.yml
@@ -1,0 +1,35 @@
+name: Bump Homebrew cask
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  bump-cask:
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute version and checksum
+        id: info
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION="${TAG#v}"
+          curl -sfL -o app.dmg "https://github.com/diffusionstudio/editor/releases/download/${TAG}/Diffusion-Studio-arm64.dmg"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "sha256=$(shasum -a 256 app.dmg | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Update tap
+        env:
+          GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          VERSION: ${{ steps.info.outputs.version }}
+          SHA256: ${{ steps.info.outputs.sha256 }}
+        run: |
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/diffusionstudio/homebrew-tap.git" tap
+          cd tap
+          sed -i "s|^  version \".*\"|  version \"${VERSION}\"|" Casks/editor.rb
+          sed -i "s|^  sha256 \".*\"|  sha256 \"${SHA256}\"|" Casks/editor.rb
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "Bump editor cask to ${VERSION}"
+          git push


### PR DESCRIPTION
Updates `Casks/editor.rb` in [diffusionstudio/homebrew-tap](https://github.com/diffusionstudio/homebrew-tap) with the new version and DMG sha256 whenever a release is published (drafts and prereleases are ignored, matching the draft-gate release flow).

Requires a `TAP_GITHUB_TOKEN` repo secret: a fine-grained PAT with contents read/write on `diffusionstudio/homebrew-tap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)