### PR TITLE
fix: invalidate in-flight fillCache work on idle()/dispose()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3535,6 +3535,13 @@
         "solid-js": "^1.8.6"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.109.0",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.109.0.tgz",
@@ -4077,6 +4084,17 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/chrome": {
       "version": "0.1.43",
       "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.43.tgz",
@@ -4087,6 +4105,13 @@
         "@types/filesystem": "*",
         "@types/har-format": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/dom-mediacapture-transform": {
       "version": "0.1.11",
@@ -4500,6 +4525,119 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vscode/sudo-prompt": {
@@ -4950,6 +5088,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ast-kit": {
       "version": "2.2.0",
@@ -5450,6 +5598,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -6701,6 +6859,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6838,6 +7006,16 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -9505,6 +9683,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -10759,6 +10951,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -11003,10 +11202,24 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stats.js": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
       "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/stream-buffers": {
@@ -11317,6 +11530,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyest": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyest/-/tinyest-0.3.2.tgz",
@@ -11337,6 +11557,16 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -11382,6 +11612,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -11992,6 +12232,109 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
@@ -12148,6 +12491,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -12482,7 +12842,8 @@
       },
       "devDependencies": {
         "@webgpu/types": "^0.1.71",
-        "typescript": "~5.9.3"
+        "typescript": "~5.9.3",
+        "vitest": "^4.1.11"
       }
     }
   }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -12,7 +12,8 @@
     "./media": "./src/media/index.ts"
   },
   "scripts": {
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test": "vitest run"
   },
   "keywords": [
     "koota",
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "@webgpu/types": "^0.1.71",
-    "typescript": "~5.9.3"
+    "typescript": "~5.9.3",
+    "vitest": "^4.1.11"
   }
 }

--- a/packages/runtime/src/media/sequence.ts
+++ b/packages/runtime/src/media/sequence.ts
@@ -227,6 +227,10 @@ export class SequenceDecoder {
 			this.idleTimer = null;
 		}
 
+		// Invalidates any fillCache still in flight, so it stops before inserting
+		// into the cache being disposed below.
+		this.seekGeneration++;
+
 		this.cache.dispose();
 	}
 
@@ -239,6 +243,10 @@ export class SequenceDecoder {
 			clearTimeout(this.idleTimer);
 			this.idleTimer = null;
 		}
+
+		// Invalidates any fillCache still in flight, so it stops before inserting
+		// into the cache being disposed below.
+		this.seekGeneration++;
 
 		this.cache.dispose();
 

--- a/packages/runtime/src/media/video.test.ts
+++ b/packages/runtime/src/media/video.test.ts
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { VideoBuffer } from './video';
+import type { EncodedPacket } from 'mediabunny';
+
+/**
+ * Regression test for idle()/dispose() not invalidating an in-flight fillCache:
+ * both used to tear down the iterator/cache without bumping `seekGeneration`, so
+ * fillCache's generation checks never noticed and kept running — reading `next()`
+ * off a nulled iterator, and inserting decoded frames into a disposed cache.
+ */
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+function packet(timestamp: number): EncodedPacket {
+  return { timestamp } as EncodedPacket;
+}
+
+interface BufferInternals {
+  iterator: { next(): Promise<{ value?: EncodedPacket; done: boolean }>; return(): Promise<unknown> } | null;
+  queue: {
+    isAlive: boolean;
+    lastSubmitted: EncodedPacket | null;
+    decode(p: EncodedPacket): Promise<void>;
+    reseed(): void;
+    dispose(): void;
+  };
+  cache: { dispose(): void; insert(...args: unknown[]): void };
+  packetSink: null;
+  keyframes: null;
+  asset: { frameRate: number };
+  firstPacketTimestamp: number;
+  seekGeneration: number;
+  mode: 'alive' | 'idle' | 'discarded';
+  idleTimer: null;
+  settleTimer: null;
+  pendingScrub: Set<number>;
+  canvas: { width: number; height: number };
+}
+
+/** Bypasses the real constructor (which needs a live decoder/OffscreenCanvas) and
+ * wires up just enough state for `fillCache`, `idle()`, and `dispose()` to run. */
+function setupBuffer(): { buffer: VideoBuffer; internals: BufferInternals } {
+  const buffer = Object.create(VideoBuffer.prototype) as VideoBuffer;
+  const internals = buffer as unknown as BufferInternals;
+
+  internals.iterator = null;
+  internals.packetSink = null;
+  internals.keyframes = null;
+  internals.asset = { frameRate: 30 };
+  internals.firstPacketTimestamp = 0;
+  internals.seekGeneration = 0;
+  internals.mode = 'alive';
+  internals.idleTimer = null;
+  internals.settleTimer = null;
+  internals.pendingScrub = new Set();
+  internals.canvas = { width: 0, height: 0 };
+  internals.cache = { dispose: () => { }, insert: () => { } };
+  internals.queue = {
+    isAlive: true,
+    lastSubmitted: packet(0),
+    decode: async () => { },
+    reseed: () => { },
+    dispose: () => { },
+  };
+
+  return { buffer, internals };
+}
+
+describe('VideoBuffer.fillCache vs idle()/dispose()', () => {
+  it('stops instead of reading next() off a nulled iterator when idle() lands mid-decode', async () => {
+    const { buffer, internals } = setupBuffer();
+
+    const nextCalls: Array<Deferred<{ value?: EncodedPacket; done: boolean }>> = [];
+    internals.iterator = {
+      next: () => {
+        const d = deferred<{ value?: EncodedPacket; done: boolean }>();
+        nextCalls.push(d);
+        return d.promise;
+      },
+      return: () => Promise.resolve(),
+    };
+
+    // idle() fires from inside queue.decode(), mirroring the real timer landing
+    // while fillCache is suspended mid-loop.
+    internals.queue.decode = async () => {
+      buffer.idle();
+    };
+
+    const fillCache = (buffer as unknown as {
+      fillCache(range: [number, number], generation: number): Promise<void>;
+    }).fillCache.bind(buffer);
+
+    const run = fillCache([0, 10], 0);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(nextCalls.length).toBeGreaterThan(0);
+    nextCalls[0]!.resolve({ value: packet(0), done: false });
+
+    await expect(run).resolves.toBeUndefined();
+
+    // idle() nulled the iterator; fillCache must not have called next() again.
+    expect(internals.iterator).toBeNull();
+    expect(nextCalls.length).toBe(1);
+  });
+
+  it('idle() and dispose() bump seekGeneration', () => {
+    const { buffer: a, internals: ia } = setupBuffer();
+    a.idle();
+    expect(ia.seekGeneration).toBe(1);
+
+    const { buffer: b, internals: ib } = setupBuffer();
+    b.dispose();
+    expect(ib.seekGeneration).toBe(1);
+  });
+});

--- a/packages/runtime/src/media/video.ts
+++ b/packages/runtime/src/media/video.ts
@@ -444,6 +444,10 @@ export class VideoBuffer {
 			this.settleTimer = null;
 		}
 
+		// Invalidates any fillCache/decodeKeyframe still in flight, so it stops
+		// before touching the cache/iterator being torn down below.
+		this.seekGeneration++;
+
 		this.pendingScrub.clear();
 		this.cache.dispose();
 		this.queue.dispose();
@@ -464,6 +468,10 @@ export class VideoBuffer {
 			clearTimeout(this.settleTimer);
 			this.settleTimer = null;
 		}
+
+		// Invalidates any fillCache/decodeKeyframe still in flight, so it stops
+		// before touching the cache/iterator being torn down below.
+		this.seekGeneration++;
 
 		this.pendingScrub.clear();
 		this.cache.dispose();


### PR DESCRIPTION
## Summary
- `VideoBuffer.idle()`/`dispose()` (video.ts) and `SequenceDecoder.idle()`/`dispose()` (sequence.ts) tear down the iterator/cache/queue without bumping `seekGeneration`. Every other mutation site (`scrubTo`, `exactSeekTo`) increments it — these two don't, so a `fillCache` already in flight never notices the teardown happened.
- Two consequences:
  - **Crash**: `fillCache`'s loop re-reads `this.iterator` each iteration; if idle()/dispose() lands mid-await and nulls it, the generation check that should catch this passes (unchanged), so the loop calls `.next()` on `null` → `TypeError: Cannot read properties of null (reading 'next')`.
  - **Leak**: even without the crash, a decoded frame can still land in `frameCallback` → `cache.insert()` after `dispose()`. `FrameCache.insert()` → `resizeCaches()` resurrects the atlas/source canvases `dispose()` explicitly zeroed out to free — undoing the teardown.
- Fix: bump `seekGeneration` in `idle()`/`dispose()` in both files, same pattern already used at the two seek entry points.
- Added a vitest regression test (`video.test.ts`) reproducing the exact crash — fails with the reported `TypeError` pre-fix, passes post-fix.

## Test plan
- [x] `cd packages/runtime && npx vitest run` — 2/2 pass, reproduces the exact reported TypeError pre-fix on unpatched code
- [x] `npx tsc --noEmit` — clean (one pre-existing unrelated error in `packages/assets`)