### PR TITLE
Linux support: fix mp4 export (no AAC encoder), ship deb/rpm/AppImage/Arch, and make dapi work

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,48 @@ jobs:
         run: cp apps/web/.env.example apps/web/.env
 
       - name: Install packaging tools
-        run: sudo apt-get update && sudo apt-get install -y dpkg-dev fakeroot rpm squashfs-tools
+        run: sudo apt-get update && sudo apt-get install -y zip dpkg-dev fakeroot rpm squashfs-tools
 
       - name: Build and publish draft release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run publish --workspace=@diffusionstudio/desktop
+
+  # Arch has no Electron Forge maker, so this job runs the makepkg script in an
+  # Arch container. It attaches its artifact to the same draft release the
+  # other two jobs publish to, and carries no Apple secrets either.
+  publish-arch:
+    runs-on: ubuntu-latest
+    container: archlinux:latest
+    permissions:
+      contents: write
+    steps:
+      # The image is minimal: actions/checkout needs git, and makepkg needs
+      # base-devel. `sudo` is here because makepkg refuses to run as root,
+      # which is what a container job starts as.
+      - name: Install build tools
+        run: |
+          pacman -Sy --noconfirm archlinux-keyring
+          pacman -Syu --noconfirm base-devel git sudo nodejs npm
+
+      - uses: actions/checkout@v4
+
+      - run: npm ci
+
+      - name: Provide client env for web build
+        run: cp apps/web/.env.example apps/web/.env
+
+      - name: Build the Arch package as an unprivileged user
+        run: |
+          useradd -m builder
+          chown -R builder .
+          sudo -u builder npm run make:arch --workspace=@diffusionstudio/desktop
+
+      - name: Attach the package to the draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pacman -S --noconfirm github-cli
+          gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1 \
+            || gh release create "$GITHUB_REF_NAME" --draft --title "$GITHUB_REF_NAME" --generate-notes
+          gh release upload "$GITHUB_REF_NAME" apps/desktop/out/arch/*.pkg.tar.zst --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         run: cp apps/web/.env.example apps/web/.env
 
       - name: Install packaging tools
-        run: sudo apt-get update && sudo apt-get install -y dpkg-dev fakeroot rpm
+        run: sudo apt-get update && sudo apt-get install -y dpkg-dev fakeroot rpm squashfs-tools
 
       - name: Build and publish draft release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,3 +54,39 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: npm run publish --workspace=@diffusionstudio/desktop
+
+  publish-linux:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Check versions match tag
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          for PKG in package.json apps/desktop/package.json apps/cli/package.json apps/web/package.json; do
+            V="$(node -p "require('./$PKG').version")"
+            if [ "$V" != "$TAG" ]; then
+              echo "Version mismatch in $PKG: $V, tag is $TAG"
+              exit 1
+            fi
+          done
+
+      - run: npm ci
+
+      - name: Provide client env for web build
+        run: cp apps/web/.env.example apps/web/.env
+
+      - name: Install packaging tools
+        run: sudo apt-get update && sudo apt-get install -y dpkg-dev fakeroot rpm
+
+      - name: Build and publish draft release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run publish --workspace=@diffusionstudio/desktop

--- a/README.md
+++ b/README.md
@@ -251,6 +251,10 @@ npm run symlink:create --workspace=@diffusionstudio/cli
 
 The link points at the CLI build, which `npm run dev:desktop` refreshes on every start, so the linked `dapi` always runs the latest code.
 
+`npm run make` builds the artifacts for the host platform: a ZIP and a DMG on macOS, and a ZIP, a `.deb`, an `.rpm` and an AppImage on Linux. The Linux makers need their own tools on the build host — `dpkg-dev` and `fakeroot` for the deb, `rpm` for the rpm, `squashfs-tools` for the AppImage — and each maker only runs when its tool is there.
+
+On a Wayland session the app runs through XWayland, which is what Chromium picks by default; native Wayland (fractional scaling, no XWayland blur) is available with `ELECTRON_OZONE_PLATFORM_HINT=auto`, though it renders incorrectly on some drivers.
+
 Before sending a PR:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -251,7 +251,9 @@ npm run symlink:create --workspace=@diffusionstudio/cli
 
 The link points at the CLI build, which `npm run dev:desktop` refreshes on every start, so the linked `dapi` always runs the latest code.
 
-`npm run make` builds the artifacts for the host platform: a ZIP and a DMG on macOS, and a ZIP, a `.deb`, an `.rpm` and an AppImage on Linux. The Linux makers need their own tools on the build host — `dpkg-dev` and `fakeroot` for the deb, `rpm` for the rpm, `squashfs-tools` for the AppImage — and each maker only runs when its tool is there.
+`npm run make` builds the artifacts for the host platform: a ZIP and a DMG on macOS, and a ZIP, a `.deb`, an `.rpm` and an AppImage on Linux. Each Linux maker needs its own tool on the build host — `zip` for the ZIP, `dpkg-dev` and `fakeroot` for the deb, `rpm` for the rpm, `squashfs-tools` for the AppImage — and fails if it is missing, so install the ones you want to build.
+
+Arch Linux has no Electron Forge maker, so its package is a script: `npm run make:arch --workspace=@diffusionstudio/desktop` writes `apps/desktop/out/arch/*.pkg.tar.zst` and needs `base-devel` (makepkg, which refuses to run as root). Every format installs the one desktop entry in [packaging/linux](packaging/linux).
 
 On a Wayland session the app runs through XWayland, which is what Chromium picks by default; native Wayland (fractional scaling, no XWayland blur) is available with `ELECTRON_OZONE_PLATFORM_HINT=auto`, though it renders incorrectly on some drivers.
 

--- a/apps/cli/src/cli-channels.ts
+++ b/apps/cli/src/cli-channels.ts
@@ -91,7 +91,8 @@ export type CheckIssueCode =
   | "never-visible"
   | "zero-duration"
   | "transparent"
-  | "source-error";
+  | "source-error"
+  | "undecodable-video";
 
 /**
  * One structural finding. `ranges` (where present) are seconds relative to

--- a/apps/cli/src/fonts.ts
+++ b/apps/cli/src/fonts.ts
@@ -63,6 +63,122 @@ function run() {
 }
 `;
 
+function listDarwinFonts(): FontFamily[] {
+  const result = spawnSync("osascript", ["-l", "JavaScript", "-e", LIST_FONTS_JXA], {
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || "Failed to enumerate fonts.");
+  }
+  return JSON.parse(result.stdout.trim()) as FontFamily[];
+}
+
+// One line per font file, so a family arrives spread over many lines and the
+// same variant repeats whenever it ships in several formats.
+const FC_LIST_FORMAT = "%{family}\\t%{style[0]}\\t%{weight}\\t%{slant}\\t%{postscriptname}\\n";
+
+// fontconfig's weight axis is its own scale, not CSS's: these are its named
+// steps paired with the CSS weight each stands for. Anything between two
+// steps is interpolated, so an unnamed intermediate weight still lands on a
+// sensible value instead of being dropped.
+const FC_WEIGHTS: readonly (readonly [fc: number, css: number])[] = [
+  [0, 100], // thin
+  [40, 200], // extralight
+  [50, 300], // light
+  [75, 400], // book
+  [80, 400], // regular
+  [100, 500], // medium
+  [180, 600], // demibold
+  [200, 700], // bold
+  [205, 800], // extrabold
+  [210, 900], // black
+];
+
+function fcWeightToCss(weight: number): string {
+  let css = 900;
+  let previous: readonly [number, number] | undefined;
+  for (const step of FC_WEIGHTS) {
+    const [fc, value] = step;
+    if (weight <= fc) {
+      css = previous ? previous[1] + ((weight - previous[0]) / (fc - previous[0])) * (value - previous[1]) : value;
+      break;
+    }
+    previous = step;
+  }
+  return String(Math.round(css / 100) * 100);
+}
+
+function listFontconfigFonts(): FontFamily[] {
+  const result = spawnSync("fc-list", ["--format", FC_LIST_FORMAT], {
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  if (result.error) {
+    throw new Error("Listing fonts needs fontconfig: `fc-list` could not be run. Install the fontconfig package.");
+  }
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || "fontconfig (`fc-list`) failed to enumerate fonts.");
+  }
+
+  // Keyed by family, then by weight+style, which collapses the repeats. A face
+  // that also carries a narrower family name ("DejaVu Sans,DejaVu Sans
+  // Condensed") is the less canonical member of the family it is filed under,
+  // so that count breaks ties for a weight and style two faces both claim.
+  const families = new Map<string, Map<string, { variant: FontVariant; names: number }>>();
+  for (const line of result.stdout.split("\n")) {
+    const [familyList, styleName, weight, slant, postscriptName] = line.split("\t");
+    if (!familyList || !weight || !slant) continue;
+
+    const familyNames = familyList.split(",");
+    const family = familyNames[0];
+    if (family.startsWith(".")) continue;
+
+    // A variable font also lists its axis ranges (`[0 210]`); those describe
+    // no single variant, and its named instances come as their own lines.
+    const fcWeight = Number(weight);
+    const fcSlant = Number(slant);
+    if (!Number.isFinite(fcWeight) || !Number.isFinite(fcSlant)) continue;
+
+    const css = fcWeightToCss(fcWeight);
+    const style = fcSlant === 0 ? "normal" : "italic";
+    let variants = families.get(family);
+    if (!variants) {
+      variants = new Map();
+      families.set(family, variants);
+    }
+    const key = `${css} ${style}`;
+    const names = familyNames.length;
+    const claimed = variants.get(key);
+    if (claimed && claimed.names <= names) continue;
+
+    const fullName = !styleName || styleName === "Regular" ? family : `${family} ${styleName}`;
+    const locals = postscriptName ? [fullName, postscriptName] : [fullName];
+    const source = locals.map((name) => `local('${name}')`).join(", ");
+    variants.set(key, { variant: { weight: css, style, source }, names });
+  }
+
+  // fc-list emits in cache order; sort so the listing reads like the macOS one.
+  return [...families]
+    .map(([family, variants]) => {
+      const sorted = [...variants.values()].map((entry) => entry.variant);
+      sorted.sort((a, b) => a.weight.localeCompare(b.weight) || a.style.localeCompare(b.style));
+      return { family, variants: sorted };
+    })
+    .sort((a, b) => a.family.localeCompare(b.family));
+}
+
+function enumerateFonts(): FontFamily[] {
+  switch (platform()) {
+    case "darwin":
+      return listDarwinFonts();
+    case "linux":
+      return listFontconfigFonts();
+    default:
+      throw new Error("fonts is only supported on macOS and Linux.");
+  }
+}
+
 export type ListLocalFontsOptions = {
   familyPattern?: string;
   weights?: string[];
@@ -71,18 +187,7 @@ export type ListLocalFontsOptions = {
 };
 
 export function listLocalFonts(options: ListLocalFontsOptions = {}): FontFamily[] {
-  if (platform() !== "darwin") {
-    throw new Error("fonts is only supported on macOS.");
-  }
-  const result = spawnSync("osascript", ["-l", "JavaScript", "-e", LIST_FONTS_JXA], {
-    encoding: "utf8",
-    maxBuffer: 16 * 1024 * 1024,
-  });
-  if (result.status !== 0) {
-    throw new Error(result.stderr.trim() || "Failed to enumerate fonts.");
-  }
-
-  const all = JSON.parse(result.stdout.trim()) as FontFamily[];
+  const all = enumerateFonts();
   const pattern = options.familyPattern?.toLowerCase();
   const weights = options.weights && options.weights.length > 0 ? new Set(options.weights) : null;
   const { style, limit } = options;

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -5,7 +5,7 @@
 
 import { execFile, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { Command } from "commander";
@@ -341,9 +341,19 @@ function launchDarwin(background: boolean): Promise<boolean> {
 // The app has to outlive this process, so the child is detached and its handle
 // released. A missing binary is reported asynchronously, which is why the two
 // events are raced instead of the call being wrapped in a try.
+//
+// `ELECTRON_RUN_AS_NODE` is how the packaged wrapper runs this CLI on the app's
+// own Electron, and a child would inherit it - starting the app in node mode,
+// where it runs no main script and exits without a window. The AppImage
+// variables go too, so an image launched from here mounts itself afresh
+// instead of reading the mount this process is running from.
 function spawnDetached(command: string, args: string[]): Promise<boolean> {
+  const env = { ...process.env };
+  delete env.ELECTRON_RUN_AS_NODE;
+  delete env.APPDIR;
+  delete env.APPIMAGE;
   const { promise, resolve: res } = Promise.withResolvers<boolean>();
-  const child = spawn(command, args, { detached: true, stdio: "ignore" });
+  const child = spawn(command, args, { detached: true, stdio: "ignore", env });
   child.once("error", () => res(false));
   child.once("spawn", () => {
     child.unref();
@@ -361,10 +371,14 @@ const LINUX_EXECUTABLE = "diffusion-studio";
 async function launchLinux(background: boolean): Promise<boolean> {
   const args = background ? ["--hidden"] : [];
 
-  // The packaged wrapper exports the root of the app it was shipped in, so an
-  // installed CLI starts its own app rather than whichever one is on PATH.
-  const root = process.env.DIFFUSION_APP_PATH;
-  const installed = root ? join(root, LINUX_EXECUTABLE) : undefined;
+  // The packaged wrapper exports what it was shipped in, so an installed CLI
+  // starts its own app rather than whichever one is on PATH: the app root for
+  // a normal install, and for an AppImage the image file, which is itself the
+  // executable.
+  const shipped = process.env.DIFFUSION_APP_PATH;
+  const installed = statSync(shipped ?? "", { throwIfNoEntry: false })?.isDirectory()
+    ? join(shipped!, LINUX_EXECUTABLE)
+    : shipped;
   if (installed && existsSync(installed) && (await spawnDetached(installed, args))) return true;
 
   if (await spawnDetached(LINUX_EXECUTABLE, args)) return true;

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -333,16 +333,63 @@ async function checkNode(id: string): Promise<void> {
 type OpenOptions = { background?: boolean };
 
 /** `open -a` on a running app only activates it, so this is safe to always run. */
-function launchApp(background: boolean): Promise<boolean> {
+function launchDarwin(background: boolean): Promise<boolean> {
   const args = background ? ["-g", "-a", APP_NAME, "--args", "--hidden"] : ["-a", APP_NAME];
   return new Promise((res) => execFile("open", args, (err) => res(!err)));
 }
 
+// The app has to outlive this process, so the child is detached and its handle
+// released. A missing binary is reported asynchronously, which is why the two
+// events are raced instead of the call being wrapped in a try.
+function spawnDetached(command: string, args: string[]): Promise<boolean> {
+  const { promise, resolve: res } = Promise.withResolvers<boolean>();
+  const child = spawn(command, args, { detached: true, stdio: "ignore" });
+  child.once("error", () => res(false));
+  child.once("spawn", () => {
+    child.unref();
+    res(true);
+  });
+  return promise;
+}
+
+// The executable electron-packager emits for the Linux build, which the deb
+// and rpm packages also expose on PATH.
+const LINUX_EXECUTABLE = "diffusion-studio";
+
+// A second instance hands its argv to the running one, so relaunching the
+// executable activates the app the same way `open -a` does on macOS.
+async function launchLinux(background: boolean): Promise<boolean> {
+  const args = background ? ["--hidden"] : [];
+
+  // The packaged wrapper exports the root of the app it was shipped in, so an
+  // installed CLI starts its own app rather than whichever one is on PATH.
+  const root = process.env.DIFFUSION_APP_PATH;
+  const installed = root ? join(root, LINUX_EXECUTABLE) : undefined;
+  if (installed && existsSync(installed) && (await spawnDetached(installed, args))) return true;
+
+  if (await spawnDetached(LINUX_EXECUTABLE, args)) return true;
+
+  // The deb and rpm packages register the `diffusion` scheme, so the desktop
+  // handler still finds the app when the executable is not on PATH. xdg-open
+  // hands the URL over and exits, reporting whether anything took it, and it
+  // forwards no arguments, so this last resort always surfaces a window.
+  const { promise, resolve: res } = Promise.withResolvers<boolean>();
+  execFile("xdg-open", ["diffusion://"], (err) => res(!err));
+  return promise;
+}
+
+function launchApp(background: boolean): Promise<boolean> {
+  if (process.platform === "darwin") return launchDarwin(background);
+  if (process.platform === "linux") return launchLinux(background);
+  return Promise.resolve(false);
+}
+
 async function openProject(path: string | undefined, opts: OpenOptions): Promise<void> {
-  // Launching is macOS's job; elsewhere (and when the app is not installed,
-  // e.g. a dev checkout run from the terminal) fall through to the socket,
-  // which answers if the app is running and errors usefully if not.
-  const launched = process.platform === "darwin" && (await launchApp(opts.background ?? false));
+  // Launching needs a way to find the app; where there is none (and when the
+  // app is not installed, e.g. a dev checkout run from the terminal) fall
+  // through to the socket, which answers if the app is running and errors
+  // usefully if not.
+  const launched = await launchApp(opts.background ?? false);
 
   try {
     // A cold launch needs the renderer up before the app can answer; when
@@ -791,7 +838,7 @@ program
 program
   .command("fonts")
   .description(
-    `List the local fonts available on this machine (macOS only; does not require the app). These family names are valid \`fontFamily\` values on <text>; each family lists its variants.`,
+    `List the local fonts available on this machine (macOS and Linux; does not require the app). These family names are valid \`fontFamily\` values on <text>; each family lists its variants.`,
   )
   .option("-f, --family <pattern>", "filter to families whose name contains <pattern> (case-insensitive)")
   .option("-w, --weight <weights...>", "filter to variants with the given CSS weight(s), e.g. -w 400 700")

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -717,7 +717,7 @@ program
 program
   .command("check")
   .description(
-    `Check a node's subtree for obvious structural mistakes, without rendering (local analysis, no credits): spans where no visual is scheduled (likely black frames), children that never become visible, zero-duration or fully transparent nodes, and assets that failed to load or generate — plus subtree stats (node count by kind, nesting depth, played duration). Prints one JSON object; times in issue ranges are seconds relative to the node's start — for a scene whose workarea starts at 0, the same clock \`capture --time\` uses. Exits 1 when an error-severity issue is found. Structural only: a scheduled clip can still render black (dark footage, content smaller than the canvas), so confirm suspicious spans visually with \`capture\`.`,
+    `Check a node's subtree for obvious structural mistakes, without rendering (local analysis, no credits): spans where no visual is scheduled (likely black frames), children that never become visible, zero-duration or fully transparent nodes, and assets that failed to load, failed to generate, or are in a codec this machine has no decoder for (an HEVC source on Linux) — plus subtree stats (node count by kind, nesting depth, played duration). Prints one JSON object; times in issue ranges are seconds relative to the node's start — for a scene whose workarea starts at 0, the same clock \`capture --time\` uses. Exits 1 when an error-severity issue is found. Structural only: a scheduled clip can still render black (dark footage, content smaller than the canvas), so confirm suspicious spans visually with \`capture\`.`,
   )
   .argument("<id>", 'node id to check or `file:id` when two files use the same id')
   .action((id: string) => checkNode(id));
@@ -732,7 +732,7 @@ const media = program
 media
   .command("probe")
   .description(
-    `Read the container and per-track technical metadata of a media file (local read, no credits): container format, duration, tags, and each track's codec params, without decoding. Commonly useful for a quick technical read, e.g. checking codec compatibility or duration before cutting. Packet stats (fps, bitrate) are estimated from a leading sample; images and transcripts report file-level info only.`,
+    `Read the container and per-track technical metadata of a media file (local read, no credits): container format, duration, tags, and each track's codec params, without decoding. Commonly useful for a quick technical read, e.g. checking codec compatibility or duration before cutting. Each video track reports \`decodable\`: whether this machine's decoder can play that codec at all — an HEVC track is typically false on Linux, and the clip renders nothing wherever it is used. Packet stats (fps, bitrate) are estimated from a leading sample; images and transcripts report file-level info only.`,
   )
   .argument("<path>", "local file path")
   .action((ref: string) => mediaProbe(ref));

--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -20,31 +20,42 @@ const { version } = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package
 // execs it, so both sides agree on the lowercase form.
 const LINUX_EXECUTABLE = 'diffusion-studio';
 
-// FreeDesktop metadata shared by every Linux artifact. The mime type is what
-// registers `diffusion://` with xdg, so the auth and checkout deep links reach
-// the app the same way the macOS bundle's protocol handler does — for the
-// AppImage only once its desktop file is integrated (by the desktop
-// environment's prompt, or AppImageLauncher).
+// The desktop entry every Linux artifact installs, kept as one file so the deb,
+// the rpm, the AppImage and the Arch package cannot drift apart - and so the
+// PKGBUILD, which no maker touches, reads the same text.
+const DESKTOP_ENTRY = join(__dirname, '..', '..', 'packaging', 'linux', `${LINUX_EXECUTABLE}.desktop`);
+
+// What the makers themselves need: the entry above carries the FreeDesktop
+// fields, these name the files.
 const linuxDesktop = {
   name: LINUX_EXECUTABLE,
-  // What lands in the desktop entry's `Exec`, and the file the AppImage maker
-  // looks for inside the packaged tree. Both default to the sanitized
-  // package name (`diffusionstudio-desktop`), which is not what is packaged.
+  // What the AppImage maker looks for inside the packaged tree, and what the
+  // deb and rpm symlink into /usr/bin. Both default to the sanitized package
+  // name (`diffusionstudio-desktop`), which is not what is packaged.
   bin: LINUX_EXECUTABLE,
   productName: 'Diffusion Studio',
-  genericName: 'Video Editor',
-  keywords: ['video', 'editor', 'agent'],
   icon: './assets/icon.png',
-  categories: ['AudioVideo', 'Video'],
-  mimeType: ['x-scheme-handler/diffusion'],
+  desktopFile: DESKTOP_ENTRY,
 } satisfies NonNullable<MakerAppImageConfig['options']>;
 
-// deb and rpm carry package metadata the desktop entry has no field for.
+// deb and rpm carry package metadata the desktop entry has no field for, and
+// they take the entry under a different option name than the AppImage maker.
+// `Maintainer` is one of the five fields dpkg-deb requires and is derived from
+// `package.json`'s `author`, which this workspace does not set - without it the
+// deb build fails outright. rpm's mandatory `License` does come from
+// `package.json` (MPL-2.0), so it needs no packager.
+const { desktopFile, ...linuxCommon } = linuxDesktop;
 const linuxPackage = {
-  ...linuxDesktop,
+  ...linuxCommon,
+  desktopTemplate: desktopFile,
   description: 'Edit videos with coding agents, and refine any output in a full editing environment',
   homepage: 'https://diffusion.studio',
 } satisfies NonNullable<MakerDebConfig['options']> & NonNullable<MakerRpmConfig['options']>;
+
+const debPackage = {
+  ...linuxPackage,
+  maintainer: 'Diffusion Studio Inc. <support@diffusion.studio>',
+} satisfies NonNullable<MakerDebConfig['options']>;
 
 const config: ForgeConfig = {
   packagerConfig: {
@@ -101,7 +112,7 @@ const config: ForgeConfig = {
       },
       ['darwin'],
     ),
-    new MakerDeb({ options: linuxPackage }, ['linux']),
+    new MakerDeb({ options: debPackage }, ['linux']),
     new MakerRpm({ options: linuxPackage }, ['linux']),
     // The format that runs on a distribution the deb and rpm do not cover:
     // one file, no root, no package manager. Needs `mksquashfs` on the build

--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -3,7 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import type { ForgeConfig } from '@electron-forge/shared-types';
+import { MakerDeb, type MakerDebConfig } from '@electron-forge/maker-deb';
 import { MakerDMG } from '@electron-forge/maker-dmg';
+import { MakerRpm, type MakerRpmConfig } from '@electron-forge/maker-rpm';
 import { MakerZIP } from '@electron-forge/maker-zip';
 import { PublisherGithub } from '@electron-forge/publisher-github';
 import { readFileSync } from 'node:fs';
@@ -11,9 +13,35 @@ import { join } from 'node:path';
 
 const { version } = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf8'));
 
+// electron-packager derives the executable name from `name` and keeps the space
+// in it, which is fine inside a .app bundle but not for a binary on $PATH. The
+// deb and rpm packages symlink this into /usr/bin and the staged CLI wrapper
+// execs it, so both sides agree on the lowercase form.
+const LINUX_EXECUTABLE = 'diffusion-studio';
+
+// FreeDesktop metadata shared by both Linux packages. The mime type is what
+// registers `diffusion://` with xdg, so the auth and checkout deep links reach
+// the app the same way the macOS bundle's protocol handler does.
+const linuxPackage = {
+  name: LINUX_EXECUTABLE,
+  productName: 'Diffusion Studio',
+  genericName: 'Video Editor',
+  description: 'Edit videos with coding agents, and refine any output in a full editing environment',
+  homepage: 'https://diffusion.studio',
+  icon: './assets/icon.png',
+  categories: ['AudioVideo', 'Video'],
+  mimeType: ['x-scheme-handler/diffusion'],
+} satisfies NonNullable<MakerDebConfig['options']> & NonNullable<MakerRpmConfig['options']>;
+
 const config: ForgeConfig = {
   packagerConfig: {
     name: 'Diffusion Studio',
+    // Only Linux renames the binary; on macOS it stays inside the bundle as
+    // `Contents/MacOS/Diffusion Studio`, which the staged CLI wrapper and the
+    // signing pass both address by that name. Read from the build host, since
+    // that is what packages a platform here — cross-packaging Linux from macOS
+    // would have to set it.
+    executableName: process.platform === 'linux' ? LINUX_EXECUTABLE : undefined,
     appBundleId: 'studio.diffusion.editor',
     appCategoryType: 'public.app-category.video',
     appVersion: version,
@@ -28,7 +56,7 @@ const config: ForgeConfig = {
       path !== '/web' &&
       !path.startsWith('/web/'),
     // Staged by scripts/stage-{cli,docs,skills}.mjs; end up at
-    // Contents/Resources/{cli,docs,skills}.
+    // Contents/Resources/{cli,docs,skills} on macOS and resources/{...} on Linux.
     extraResource: ['./cli', './docs', './skills'],
     osxSign: process.env.SKIP_SIGN ? undefined : {},
     osxNotarize:
@@ -41,22 +69,27 @@ const config: ForgeConfig = {
         : undefined,
   },
   makers: [
-    new MakerZIP({}, ['darwin']),
-    new MakerDMG({
-      name: `Diffusion-Studio-${process.arch}`,
-      icon: './assets/icon.icns',
-      // Dark, on-brand window; @2x sibling is picked up automatically for retina.
-      background: './assets/dmg-background.png',
-      iconSize: 120,
-      additionalDMGOptions: {
-        'background-color': '#1c1c1c',
-        window: { size: { width: 658, height: 498 } },
+    new MakerZIP({}, ['darwin', 'linux']),
+    new MakerDMG(
+      {
+        name: `Diffusion-Studio-${process.arch}`,
+        icon: './assets/icon.icns',
+        // Dark, on-brand window; @2x sibling is picked up automatically for retina.
+        background: './assets/dmg-background.png',
+        iconSize: 120,
+        additionalDMGOptions: {
+          'background-color': '#1c1c1c',
+          window: { size: { width: 658, height: 498 } },
+        },
+        contents: (opts) => [
+          { x: 188, y: 217, type: 'file', path: opts.appPath },
+          { x: 470, y: 217, type: 'link', path: '/Applications' },
+        ],
       },
-      contents: (opts) => [
-        { x: 188, y: 217, type: 'file', path: opts.appPath },
-        { x: 470, y: 217, type: 'link', path: '/Applications' },
-      ],
-    }),
+      ['darwin'],
+    ),
+    new MakerDeb({ options: linuxPackage }, ['linux']),
+    new MakerRpm({ options: linuxPackage }, ['linux']),
   ],
   publishers: [
     new PublisherGithub({

--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -4,6 +4,7 @@
 
 import type { ForgeConfig } from '@electron-forge/shared-types';
 import { MakerDeb, type MakerDebConfig } from '@electron-forge/maker-deb';
+import MakerAppImage, { type MakerAppImageConfig } from '@reforged/maker-appimage';
 import { MakerDMG } from '@electron-forge/maker-dmg';
 import { MakerRpm, type MakerRpmConfig } from '@electron-forge/maker-rpm';
 import { MakerZIP } from '@electron-forge/maker-zip';
@@ -19,18 +20,30 @@ const { version } = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package
 // execs it, so both sides agree on the lowercase form.
 const LINUX_EXECUTABLE = 'diffusion-studio';
 
-// FreeDesktop metadata shared by both Linux packages. The mime type is what
+// FreeDesktop metadata shared by every Linux artifact. The mime type is what
 // registers `diffusion://` with xdg, so the auth and checkout deep links reach
-// the app the same way the macOS bundle's protocol handler does.
-const linuxPackage = {
+// the app the same way the macOS bundle's protocol handler does — for the
+// AppImage only once its desktop file is integrated (by the desktop
+// environment's prompt, or AppImageLauncher).
+const linuxDesktop = {
   name: LINUX_EXECUTABLE,
+  // What lands in the desktop entry's `Exec`, and the file the AppImage maker
+  // looks for inside the packaged tree. Both default to the sanitized
+  // package name (`diffusionstudio-desktop`), which is not what is packaged.
+  bin: LINUX_EXECUTABLE,
   productName: 'Diffusion Studio',
   genericName: 'Video Editor',
-  description: 'Edit videos with coding agents, and refine any output in a full editing environment',
-  homepage: 'https://diffusion.studio',
+  keywords: ['video', 'editor', 'agent'],
   icon: './assets/icon.png',
   categories: ['AudioVideo', 'Video'],
   mimeType: ['x-scheme-handler/diffusion'],
+} satisfies NonNullable<MakerAppImageConfig['options']>;
+
+// deb and rpm carry package metadata the desktop entry has no field for.
+const linuxPackage = {
+  ...linuxDesktop,
+  description: 'Edit videos with coding agents, and refine any output in a full editing environment',
+  homepage: 'https://diffusion.studio',
 } satisfies NonNullable<MakerDebConfig['options']> & NonNullable<MakerRpmConfig['options']>;
 
 const config: ForgeConfig = {
@@ -90,6 +103,10 @@ const config: ForgeConfig = {
     ),
     new MakerDeb({ options: linuxPackage }, ['linux']),
     new MakerRpm({ options: linuxPackage }, ['linux']),
+    // The format that runs on a distribution the deb and rpm do not cover:
+    // one file, no root, no package manager. Needs `mksquashfs` on the build
+    // host (squashfs-tools).
+    new MakerAppImage({ options: linuxDesktop }, ['linux']),
   ],
   publishers: [
     new PublisherGithub({

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -26,7 +26,9 @@
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.11.1",
+    "@electron-forge/maker-deb": "^7.11.1",
     "@electron-forge/maker-dmg": "^7.11.1",
+    "@electron-forge/maker-rpm": "^7.11.1",
     "@electron-forge/maker-zip": "^7.11.1",
     "@electron-forge/publisher-github": "^7.11.1",
     "@types/babel__core": "^7.20.5",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -31,6 +31,7 @@
     "@electron-forge/maker-rpm": "^7.11.1",
     "@electron-forge/maker-zip": "^7.11.1",
     "@electron-forge/publisher-github": "^7.11.1",
+    "@reforged/maker-appimage": "^5.3.1",
     "@types/babel__core": "^7.20.5",
     "@types/node": "^24.10.1",
     "electron": "^43.1.1",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,6 +22,7 @@
     "package": "npm run build && npm run build:web && npm run stage:cli && npm run stage:docs && npm run stage:skills && electron-forge package",
     "make": "npm run build && npm run build:web && npm run stage:cli && npm run stage:docs && npm run stage:skills && electron-forge make",
     "publish": "npm run build && npm run build:web && npm run stage:cli && npm run stage:docs && npm run stage:skills && electron-forge publish",
+    "make:arch": "npm run package && node scripts/make-arch.mjs",
     "make:icns": "sh scripts/make-icns.sh"
   },
   "devDependencies": {

--- a/apps/desktop/scripts/make-arch.mjs
+++ b/apps/desktop/scripts/make-arch.mjs
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// Builds an Arch Linux package (.pkg.tar.zst) from the `electron-forge package`
+// output. Electron Forge has no Arch maker, so this is a script rather than a
+// maker; run it after `npm run package` (or `npm run make`).
+//
+// Adapted from https://github.com/diffusionstudio/editor/pull/42 by @Tsurgcom.
+// The staged tree lives in out/arch and the package lands beside it.
+import { execFileSync } from "node:child_process";
+import { cpSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const desktopDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = join(desktopDir, "..", "..");
+const require = createRequire(import.meta.url);
+const { version } = require(join(repoRoot, "package.json"));
+
+const PKG_NAME = "diffusion-studio";
+const outDir = join(desktopDir, "out");
+
+// electron-packager names the directory after the product, not the executable.
+const packaged = readdirSync(outDir).find((entry) => entry.startsWith("Diffusion Studio-linux-"));
+if (!packaged) {
+  console.error("make-arch: nothing packaged in out/. Run `npm run package` first.");
+  process.exit(1);
+}
+
+const archDir = join(outDir, "arch");
+rmSync(archDir, { recursive: true, force: true });
+mkdirSync(archDir, { recursive: true });
+
+// What makepkg unpacks: the app plus the two files the PKGBUILD installs.
+const srcName = `${PKG_NAME}-${version}-linux-x64`;
+const srcDir = join(archDir, srcName);
+cpSync(join(outDir, packaged), srcDir, { recursive: true });
+cpSync(join(repoRoot, "packaging", "linux", `${PKG_NAME}.desktop`), join(srcDir, `${PKG_NAME}.desktop`));
+cpSync(join(desktopDir, "assets", "icon.png"), join(srcDir, `${PKG_NAME}.png`));
+
+const tarball = `${srcName}.tar.gz`;
+execFileSync("tar", ["-czf", join(archDir, tarball), "-C", archDir, srcName], { stdio: "inherit" });
+
+writeFileSync(
+  join(archDir, "PKGBUILD"),
+  readFileSync(join(repoRoot, "packaging", "arch", "PKGBUILD"), "utf8").replaceAll("__VERSION__", version),
+);
+
+// makepkg refuses to run as root, which is what a container CI job starts as -
+// the workflow builds this step as an unprivileged user for that reason.
+execFileSync("makepkg", ["-f", "--noconfirm"], {
+  cwd: archDir,
+  stdio: "inherit",
+  env: { ...process.env, PACKAGER: "Diffusion Studio Inc. <support@diffusion.studio>" },
+});
+
+const built = readdirSync(archDir).find((entry) => entry.endsWith(".pkg.tar.zst"));
+console.log(`make-arch: wrote ${join(archDir, built)}`);

--- a/apps/desktop/scripts/stage-cli.mjs
+++ b/apps/desktop/scripts/stage-cli.mjs
@@ -50,7 +50,12 @@ execFileSync("npm", ["install", "--omit=dev", "--no-audit", "--no-fund", "--no-p
 
 // The wrapper runs the CLI bundle on the app's own Electron binary in Node
 // mode, so users need no separate Node install. It resolves symlinks first
-// because both Homebrew and the in-app installer link it into PATH.
+// because both Homebrew and the in-app installer link it into PATH, then
+// works out which packaged layout it sits in: on macOS the wrapper is at
+// Contents/Resources/cli/bin, beside Contents/MacOS, while electron-packager
+// emits a flat Linux tree with resources/ next to the executable — one level
+// closer to the app root. The Linux name is packagerConfig.executableName
+// (see forge.config.ts), which only that build renames.
 const wrapper = `#!/bin/sh
 SELF="$0"
 while [ -L "$SELF" ]; do
@@ -61,8 +66,19 @@ while [ -L "$SELF" ]; do
   esac
 done
 DIR="$(cd "$(dirname "$SELF")" && pwd)"
-export DIFFUSION_APP_PATH="$(cd "$DIR/../../../.." && pwd)"
-ELECTRON_RUN_AS_NODE=1 exec "$DIR/../../../MacOS/Diffusion Studio" "$DIR/../dapi.js" "$@"
+if [ -x "$DIR/../../../MacOS/Diffusion Studio" ]; then
+  ELECTRON="$DIR/../../../MacOS/Diffusion Studio"
+  APP_ROOT="$DIR/../../../.."
+else
+  APP_ROOT="$DIR/../../.."
+  ELECTRON="$APP_ROOT/diffusion-studio"
+  if [ ! -x "$ELECTRON" ]; then
+    echo "dapi: no application executable at $ELECTRON" >&2
+    exit 1
+  fi
+fi
+export DIFFUSION_APP_PATH="$(cd "$APP_ROOT" && pwd)"
+ELECTRON_RUN_AS_NODE=1 exec "$ELECTRON" "$DIR/../dapi.js" "$@"
 `;
 writeFileSync(join(stageDir, "bin", "dapi"), wrapper);
 chmodSync(join(stageDir, "bin", "dapi"), 0o755);

--- a/apps/desktop/src/cli-install.ts
+++ b/apps/desktop/src/cli-install.ts
@@ -4,29 +4,45 @@
 
 import { app } from "electron";
 import { execFile } from "node:child_process";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 import type { CliInstallResult } from "./main-channels";
 
-export const CLI_LINK_PATH = "/usr/local/bin/dapi";
+// Where each platform keeps user-installed commands: /usr/local/bin needs
+// elevation, ~/.local/bin is on PATH on modern distributions and belongs to
+// the user, so linking there asks for nothing.
+export const CLI_LINK_PATH =
+  process.platform === "linux" ? join(homedir(), ".local", "bin", "dapi") : "/usr/local/bin/dapi";
 
 // The dev workflow links the workspace build into Homebrew's bin instead
 // (`symlink:create` in apps/cli), so both locations count as installed.
 const DEV_LINK_PATH = "/opt/homebrew/bin/dapi";
 
 export function isCliInstalled(): boolean {
-  return existsSync(CLI_LINK_PATH) || existsSync(DEV_LINK_PATH);
+  if (existsSync(CLI_LINK_PATH)) return true;
+  return process.platform === "darwin" && existsSync(DEV_LINK_PATH);
 }
+
+// The staged wrapper inside the app's resources, the file both platforms link.
+const CLI_WRAPPER_PATH = join(process.resourcesPath, "cli", "bin", "dapi");
 
 // Linking into /usr/local/bin needs elevation; osascript shows the standard
 // macOS admin prompt so the app itself never asks for credentials.
-function linkCli(): Promise<void> {
-  const wrapper = join(process.resourcesPath, "cli", "bin", "dapi");
-  const shell = `mkdir -p /usr/local/bin && ln -sf '${wrapper}' '${CLI_LINK_PATH}'`;
+function linkCliWithPrompt(): Promise<void> {
+  const shell = `mkdir -p /usr/local/bin && ln -sf '${CLI_WRAPPER_PATH}' '${CLI_LINK_PATH}'`;
   const script = `do shell script "${shell.replaceAll('"', '\\"')}" with administrator privileges`;
   return new Promise((resolve, reject) => {
     execFile("osascript", ["-e", script], (err) => (err ? reject(err) : resolve()));
   });
+}
+
+// The user owns ~/.local/bin, so the link is a plain filesystem operation.
+// Replacing an existing link mirrors `ln -sf`.
+function linkCliDirectly(): void {
+  mkdirSync(dirname(CLI_LINK_PATH), { recursive: true });
+  rmSync(CLI_LINK_PATH, { force: true });
+  symlinkSync(CLI_WRAPPER_PATH, CLI_LINK_PATH);
 }
 
 export async function installCli(): Promise<CliInstallResult> {
@@ -37,7 +53,8 @@ export async function installCli(): Promise<CliInstallResult> {
     };
   }
   try {
-    await linkCli();
+    if (process.platform === "linux") linkCliDirectly();
+    else await linkCliWithPrompt();
     return { status: "installed" };
   } catch (e) {
     const message = (e as Error).message ?? "";

--- a/apps/desktop/src/cli-install.ts
+++ b/apps/desktop/src/cli-install.ts
@@ -52,6 +52,20 @@ export async function installCli(): Promise<CliInstallResult> {
       error: "Installing the CLI is only available in the packaged app. Use `npm run symlink:create` in development.",
     };
   }
+
+  // An AppImage runs from a mount that only exists while it does
+  // (`/tmp/.mount_*`), so a link into its resources would dangle the moment
+  // the app quits. The bundled `dapi` works fine from inside a running one —
+  // it just has no path worth linking.
+  if (process.env.APPIMAGE) {
+    return {
+      status: "error",
+      error:
+        "An AppImage has no stable path to link from. Install the deb or rpm package to get dapi on PATH, " +
+        "or unpack this file once (`--appimage-extract`) and link the dapi wrapper under " +
+        "usr/lib/diffusion-studio/resources/cli/bin from the unpacked tree.",
+    };
+  }
   try {
     if (process.platform === "linux") linkCliDirectly();
     else await linkCliWithPrompt();

--- a/apps/desktop/src/cli-install.ts
+++ b/apps/desktop/src/cli-install.ts
@@ -10,8 +10,9 @@ import { dirname, join } from "node:path";
 import type { CliInstallResult } from "./main-channels";
 
 // Where each platform keeps user-installed commands: /usr/local/bin needs
-// elevation, ~/.local/bin is on PATH on modern distributions and belongs to
-// the user, so linking there asks for nothing.
+// elevation, ~/.local/bin belongs to the user, so linking there asks for
+// nothing. Debian and Fedora put it on PATH for you, but not every
+// distribution does, so the menu checks before claiming the command is ready.
 export const CLI_LINK_PATH =
   process.platform === "linux" ? join(homedir(), ".local", "bin", "dapi") : "/usr/local/bin/dapi";
 

--- a/apps/desktop/src/cli-install.ts
+++ b/apps/desktop/src/cli-install.ts
@@ -4,9 +4,9 @@
 
 import { app } from "electron";
 import { execFile } from "node:child_process";
-import { existsSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, relative } from "node:path";
 import type { CliInstallResult } from "./main-channels";
 
 // Where each platform keeps user-installed commands: /usr/local/bin needs
@@ -46,6 +46,39 @@ function linkCliDirectly(): void {
   symlinkSync(CLI_WRAPPER_PATH, CLI_LINK_PATH);
 }
 
+// An AppImage has nothing worth linking to: it runs from a mount under /tmp
+// that exists only while the process does, and whose name changes every
+// launch, so a symlink into `resources` dangles the moment the app quits. The
+// image file itself is stable and can run the CLI through Electron's node
+// mode, mounting itself for the duration of the call - so the install writes a
+// wrapper that does that. The path inside the mount is read from this process
+// rather than assumed, since it is the maker that decides the layout.
+function writeAppImageWrapper(appImage: string, appDir: string): void {
+  const insideMount = relative(appDir, dirname(process.resourcesPath));
+  // Runs in the child: the runtime exports APPDIR for the mount it made and
+  // APPIMAGE for the file, which is what `dapi open` needs to launch the app.
+  const bootstrap =
+    `const r=process.env.APPDIR+"/${insideMount}";` +
+    `process.env.DIFFUSION_APP_PATH=process.env.APPIMAGE;` +
+    `const j=r+"/resources/cli/dapi.js";` +
+    `process.argv=[process.argv[0],j,...process.argv.slice(1)];` +
+    `require(j);`;
+  const quoted = `'${appImage.replaceAll("'", `'\\''`)}'`;
+  const wrapper = [
+    "#!/bin/sh",
+    "# Written by Diffusion Studio's \"Install dapi Command Line Tool\" from an",
+    "# AppImage. Move or delete that file and this stops working; run the",
+    "# installer again to point it at the new location.",
+    `APPIMAGE=${quoted}`,
+    `[ -x "$APPIMAGE" ] || { echo "dapi: no Diffusion Studio AppImage at $APPIMAGE" >&2; exit 1; }`,
+    `ELECTRON_RUN_AS_NODE=1 exec "$APPIMAGE" -e '${bootstrap}' -- "$@"`,
+    "",
+  ].join("\n");
+  mkdirSync(dirname(CLI_LINK_PATH), { recursive: true });
+  rmSync(CLI_LINK_PATH, { force: true });
+  writeFileSync(CLI_LINK_PATH, wrapper, { mode: 0o755 });
+}
+
 export async function installCli(): Promise<CliInstallResult> {
   if (!app.isPackaged) {
     return {
@@ -53,22 +86,10 @@ export async function installCli(): Promise<CliInstallResult> {
       error: "Installing the CLI is only available in the packaged app. Use `npm run symlink:create` in development.",
     };
   }
-
-  // An AppImage runs from a mount that only exists while it does
-  // (`/tmp/.mount_*`), so a link into its resources would dangle the moment
-  // the app quits. The bundled `dapi` works fine from inside a running one —
-  // it just has no path worth linking.
-  if (process.env.APPIMAGE) {
-    return {
-      status: "error",
-      error:
-        "An AppImage has no stable path to link from. Install the deb or rpm package to get dapi on PATH, " +
-        "or unpack this file once (`--appimage-extract`) and link the dapi wrapper under " +
-        "usr/lib/diffusion-studio/resources/cli/bin from the unpacked tree.",
-    };
-  }
+  const { APPIMAGE, APPDIR } = process.env;
   try {
-    if (process.platform === "linux") linkCliDirectly();
+    if (APPIMAGE && APPDIR) writeAppImageWrapper(APPIMAGE, APPDIR);
+    else if (process.platform === "linux") linkCliDirectly();
     else await linkCliWithPrompt();
     return { status: "installed" };
   } catch (e) {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -57,6 +57,15 @@ app.commandLine.appendSwitch("disable-renderer-backgrounding");
 app.commandLine.appendSwitch("disable-backgrounding-occluded-windows");
 app.commandLine.appendSwitch("disable-features", "CalculateNativeWinOcclusion");
 
+// No ozone hint is set here on purpose. Native Wayland would buy fractional
+// scaling, but on a KDE 6.7 Wayland session with the proprietary NVIDIA driver
+// it presents a broken surface — Chromium logs that Wayland and Vulkan are
+// incompatible, the renderer paints correctly (a DevTools capture is right)
+// and the window still comes up blank or without glyphs. XWayland, which is
+// what Chromium picks by default, is correct there. Electron reads
+// `ELECTRON_OZONE_PLATFORM_HINT=auto` from the environment, so anyone whose
+// session handles native Wayland can opt in without a build of their own.
+
 let setNativeCornerRadius: ((handle: Buffer, radius: number) => void) | null = null;
 let setNativeBackdrop:
   | ((handle: Buffer, blur: number, r: number, g: number, b: number, a: number) => void)

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -51,7 +51,24 @@ const MACOS_BACKDROP = { blur: 80, red: 0.07, green: 0.07, blue: 0.07, alpha: 0.
 
 app.setName("Diffusion Studio");
 app.commandLine.appendSwitch("enable-blink-features", "CanvasDrawElement");
-app.commandLine.appendSwitch("enable-features", "SharedArrayBuffer");
+// Chromium ships software decoders for H.264, VP9 and AV1 — and none for HEVC,
+// which is platform-decoder-only. On Linux that decoder is VA-API, which
+// upstream keeps off on NVIDIA (crbug.com/1492880), so an HEVC source there
+// imports fine and then renders nothing. `PlatformHEVCDecoderSupport` is on by
+// default already, so the switch below is not what decides it; the library asks
+// the platform per machine and warns when the answer is no (decodability in
+// @diffusionstudio/assets). Left at upstream's defaults on purpose — if HEVC on
+// Linux ever needs to render rather than be reported:
+//   - Enable VA-API on NVIDIA: `VaapiOnNvidiaGPUs`, plus
+//     `--ignore-gpu-blocklist`, plus `LIBVA_DRIVER_NAME=nvidia` (libva 2.20+
+//     will not pick it over mesa's on its own) — only where NVIDIA is the sole
+//     GPU, since that variable is process-wide and on a hybrid box would move
+//     libva off the iGPU Chromium renders on. It only helps where the driver
+//     advertises the decode profiles, which is not a given.
+//   - Register a WASM HEVC decoder (e.g. libde265) through mediabunny's
+//     `registerDecoder`, which its decode path consults: HEVC renders on any
+//     machine, at CPU-decode cost and a larger bundle.
+app.commandLine.appendSwitch("enable-features", "SharedArrayBuffer,PlatformHEVCDecoderSupport");
 app.commandLine.appendSwitch("disable-background-timer-throttling");
 app.commandLine.appendSwitch("disable-renderer-backgrounding");
 app.commandLine.appendSwitch("disable-backgrounding-occluded-windows");

--- a/apps/desktop/src/menu.ts
+++ b/apps/desktop/src/menu.ts
@@ -25,20 +25,24 @@ async function installCliFromMenu() {
   }
 }
 
-export function setupAppMenu() {
-  if (process.platform !== "darwin") return;
+/** The one app-specific item both menus carry; only the packaged app can link it. */
+function installCliItem(): MenuItemConstructorOptions {
+  return {
+    label: "Install dapi Command Line Tool…",
+    enabled: app.isPackaged,
+    click: installCliFromMenu,
+  };
+}
 
-  const template: MenuItemConstructorOptions[] = [
+/** The macOS menu: the app menu holds the item, in its usual place. */
+function macTemplate(): MenuItemConstructorOptions[] {
+  return [
     {
       label: app.name,
       submenu: [
         { role: "about" },
         { type: "separator" },
-        {
-          label: "Install dapi Command Line Tool…",
-          enabled: app.isPackaged,
-          click: installCliFromMenu,
-        },
+        installCliItem(),
         { type: "separator" },
         { role: "services" },
         { type: "separator" },
@@ -54,6 +58,27 @@ export function setupAppMenu() {
     { role: "viewMenu" },
     { role: "windowMenu" },
   ];
+}
 
+/**
+ * Everywhere else there is no app menu, so the item goes under File. Without
+ * a template of our own Electron shows its stock menu, which has no way to
+ * reach the installer at all — and the roles the macOS template uses
+ * (`about`, `services`, `hide`) are AppKit's, so they have no place here.
+ */
+function defaultTemplate(): MenuItemConstructorOptions[] {
+  return [
+    {
+      label: "File",
+      submenu: [installCliItem(), { type: "separator" }, { role: "quit" }],
+    },
+    { role: "editMenu" },
+    { role: "viewMenu" },
+    { role: "windowMenu" },
+  ];
+}
+
+export function setupAppMenu() {
+  const template = process.platform === "darwin" ? macTemplate() : defaultTemplate();
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }

--- a/apps/desktop/src/menu.ts
+++ b/apps/desktop/src/menu.ts
@@ -4,6 +4,7 @@
 
 import { app, dialog, Menu } from "electron";
 import type { MenuItemConstructorOptions } from "electron";
+import { dirname } from "node:path";
 
 import { CLI_LINK_PATH, installCli } from "./cli-install";
 
@@ -11,10 +12,17 @@ async function installCliFromMenu() {
   const result = await installCli();
   if (result.status === "cancelled") return;
   if (result.status === "installed") {
+    // The session PATH is what a launcher-started app inherits; a directory
+    // only a shell rc file adds reads as missing, so this is worded as a
+    // condition rather than a claim about the user's shell.
+    const linkDir = dirname(CLI_LINK_PATH);
+    const onPath = (process.env.PATH ?? "").split(":").includes(linkDir);
     await dialog.showMessageBox({
       type: "info",
       message: "The dapi command line tool was installed.",
-      detail: `Linked at ${CLI_LINK_PATH}. Run "dapi --help" in a terminal to get started.`,
+      detail: onPath
+        ? `Linked at ${CLI_LINK_PATH}. Run "dapi --help" in a terminal to get started.`
+        : `Linked at ${CLI_LINK_PATH}. If "dapi" is not found, add ${linkDir} to your PATH.`,
     });
   } else {
     await dialog.showMessageBox({

--- a/apps/desktop/src/menu.ts
+++ b/apps/desktop/src/menu.ts
@@ -21,8 +21,8 @@ async function installCliFromMenu() {
       type: "info",
       message: "The dapi command line tool was installed.",
       detail: onPath
-        ? `Linked at ${CLI_LINK_PATH}. Run "dapi --help" in a terminal to get started.`
-        : `Linked at ${CLI_LINK_PATH}. If "dapi" is not found, add ${linkDir} to your PATH.`,
+        ? `Installed at ${CLI_LINK_PATH}. Run "dapi --help" in a terminal to get started.`
+        : `Installed at ${CLI_LINK_PATH}. If "dapi" is not found, add ${linkDir} to your PATH.`,
     });
   } else {
     await dialog.showMessageBox({

--- a/apps/web/src/components/sidebar-right/inspector/export-templates.ts
+++ b/apps/web/src/components/sidebar-right/inspector/export-templates.ts
@@ -23,6 +23,7 @@ export const RESOLUTION_OPTIONS: number[] = [720, 1080, 1440, 2160];
 export const VIDEO_CODEC_OPTIONS: VideoCodec[] = ["avc", "hevc", "vp9", "av1", "vp8"];
 export const VIDEO_FORMAT_OPTIONS: ContainerFormat[] = ["mp4", "webm", "ogg", "mov"];
 export const FRAME_RATE_OPTIONS: number[] = [24, 25, 29.97, 30, 48, 50, 59.94, 60];
+/** The codecs the audio picker offers, less the ones a machine cannot encode (see `ExportPanel`). */
 export const AUDIO_CODEC_OPTIONS: AudioCodec[] = ["aac", "opus"];
 export const SAMPLE_RATE_OPTIONS: number[] = [44100, 48000, 96000];
 

--- a/apps/web/src/components/sidebar-right/inspector/export.tsx
+++ b/apps/web/src/components/sidebar-right/inspector/export.tsx
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Show, createMemo, createResource, createSignal } from "solid-js";
-import { canEncodeVideo } from "mediabunny";
-import { computeOutputSize } from "@diffusionstudio/encoder";
+import { canEncodeVideo, getEncodableAudioCodecs } from "mediabunny";
+import { audioCodecsForFormat, computeOutputSize, resolveAudioCodec } from "@diffusionstudio/encoder";
 import { PanelSection } from "@/components/ui/panel-section";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -158,6 +158,28 @@ export function ExportPanel(props: ExportPanelProps) {
     ({ codec, bitrate, width, height }) => canEncodeVideo(codec, { width, height, bitrate }),
   );
 
+  // Which audio codecs are worth offering: those the container takes and
+  // this browser can encode. AAC is a platform encoder in WebCodecs
+  // (AudioToolbox on macOS, Media Foundation on Windows) and simply absent
+  // on Linux, so offering it there would only fail the export.
+  const [audioCodecs] = createResource(
+    () => {
+      const current = settings();
+      return {
+        format: current?.format ?? ("mp4" as const),
+        sampleRate: current?.audio?.sampleRate,
+        bitrate: current?.audio?.bitrate,
+      };
+    },
+    async ({ format, ...options }) => {
+      const [supported, encodable] = await Promise.all([
+        audioCodecsForFormat(format),
+        getEncodableAudioCodecs([...AUDIO_CODEC_OPTIONS], options),
+      ]);
+      return encodable.filter((codec) => supported.includes(codec));
+    },
+  );
+
   // Audio-only exports always encode
   const exportSupported = createMemo(() => {
     const current = settings();
@@ -180,14 +202,21 @@ export function ExportPanel(props: ExportPanelProps) {
     void config()?.setExport(entity(), value);
   };
 
-  // Replaces the settings with a preset's, wholesale.
-  const applyTemplate = (id: string) => {
+  // Replaces the settings with a preset's, wholesale. A preset names AAC for
+  // mp4, which is a preference rather than a demand — what is written is the
+  // codec this browser can encode into the container.
+  const applyTemplate = async (id: string) => {
     const next = templateSettings(id);
-    if (next) write(next);
+    if (!next) return;
+    const codec = await resolveAudioCodec(next.format, next.audio?.codec, {
+      sampleRate: next.audio?.sampleRate,
+      bitrate: next.audio?.bitrate,
+    });
+    write(codec ? { ...next, audio: { ...next.audio, codec } } : next);
   };
 
   const addSettings = () => {
-    applyTemplate(DEFAULT_EXPORT_TEMPLATE_ID);
+    void applyTemplate(DEFAULT_EXPORT_TEMPLATE_ID);
     setIsInspectorOpen(true);
   };
 
@@ -294,6 +323,7 @@ export function ExportPanel(props: ExportPanelProps) {
             settings={current()}
             resolutionOptions={resolutionOptions()}
             selectedResolution={selectedResolution()}
+            audioCodecOptions={audioCodecs() ?? AUDIO_CODEC_OPTIONS}
             anchorRef={inspectorAnchorRef}
             onClose={() => setIsInspectorOpen(false)}
             onSelectTemplate={applyTemplate}
@@ -309,6 +339,7 @@ type ExportInspectorProps = {
   settings: ProjectExportConfig;
   resolutionOptions: ResolutionOption[];
   selectedResolution: ResolutionOption | null;
+  audioCodecOptions: AudioCodec[];
   anchorRef: HTMLDivElement | undefined;
   onClose: () => void;
   onSelectTemplate: (id: string) => void;
@@ -507,7 +538,7 @@ function ExportInspector(props: ExportInspectorProps) {
             <ControlRow label="Codec">
               <Select
                 value={config().audio?.codec ?? "aac"}
-                options={[...AUDIO_CODEC_OPTIONS]}
+                options={[...props.audioCodecOptions]}
                 onChange={(value) => value && write({ audio: { codec: value } })}
                 itemComponent={(itemProps) => (
                   <SelectItem item={itemProps.item}>{itemProps.item.rawValue.toUpperCase()}</SelectItem>

--- a/apps/web/src/context/dapi/check.ts
+++ b/apps/web/src/context/dapi/check.ts
@@ -4,14 +4,15 @@
 
 import {
   AdjustmentLayer, Audio, Cache, Caption, Computed, FrameRate, Geometry,
-  Group, Hidden, IsMask, Opacity, PaintType, Scene, Sequential, Source,
-  SourceError, Workarea, framesToSeconds, getIntrinsicPaint, isText,
+  Group, Hidden, IsMask, Opacity, Paint, PaintType, Scene, Sequential, Source,
+  SourceError, Workarea, findGeometryAsset, framesToSeconds, getIntrinsicPaint, isText,
 } from "@diffusionstudio/runtime";
+import { canDecodeVideoCodec } from "@diffusionstudio/assets";
 
 import { resolveNode } from "./nodes";
 
 import type { CheckIssue, CheckRequest, CheckResult } from "@diffusionstudio/cli/channels";
-import type { Entity } from "koota";
+import type { Entity, World } from "koota";
 import type { EditorSession } from "./session";
 
 // Absolute frames, [start, end).
@@ -46,12 +47,34 @@ function drawsPixels(entity: Entity): boolean {
     && !entity.has(Audio);
 }
 
+/**
+ * The sub-entities a node paints video through: itself, when its own paint is
+ * the footage, and every video paint child (a `<videoPaint>` filling the node
+ * with a clip). A paint child carries the asset instead of the geometry, so
+ * both have to be asked.
+ */
+function videoSources(entity: Entity): Entity[] {
+  const sources: Entity[] = [];
+  if (getIntrinsicPaint(entity) === PaintType.VIDEO) sources.push(entity);
+  for (const fill of entity.get(Cache)?.fills ?? []) {
+    if (fill.get(Paint)?.value === PaintType.VIDEO) sources.push(fill);
+  }
+  return sources;
+}
+
 type WalkState = {
+  world: World;
   nodes: number;
   byKind: Record<string, number>;
   depth: number;
   issues: CheckIssue[];
   coverage: Interval[];
+  /**
+   * Video sources seen on the walk, resolved for decodability once it is over.
+   * `id` keys the finding (a node need not carry a source stamp), `node` names
+   * it in the message.
+   */
+  videos: Array<{ id: number; node: string | undefined; codec: string | null | undefined }>;
   /** Frames→seconds on the checked node's own clock (capture --time's). */
   rel: (frames: number) => number;
 };
@@ -78,6 +101,17 @@ function visit(entity: Entity, window: Interval | null, depth: number, state: Wa
       node: stamp,
       message: `Source failed to ${failure.generated ? "generate" : "load"}: ${failure.value}`,
     });
+  }
+
+  // An asset loads fine and renders nothing in the timeline when this
+  // machine has no decoder for its codec. Which codecs this machine has is
+  // not known until asked, so the walk only notes the sources; the answer
+  // arrives once, afterwards, for each codec involved.
+  for (const source of videoSources(entity)) {
+    const asset = findGeometryAsset(state.world, source);
+    if (asset?.type === "VIDEO") {
+      state.videos.push({ id: entity.id(), node: stamp, codec: asset.codec });
+    }
   }
 
   const computed = entity.get(Computed)!;
@@ -167,8 +201,29 @@ export function handleCheck(session: () => EditorSession) {
     }
 
     const rel = (frames: number) => Math.round(framesToSeconds(frames - computed.start, fps) * 1000) / 1000;
-    const state: WalkState = { nodes: 0, byKind: {}, depth: 0, issues: [], coverage: [], rel };
+    const state: WalkState = { world, nodes: 0, byKind: {}, depth: 0, issues: [], coverage: [], videos: [], rel };
     visit(target, window, 0, state);
+
+    // One question per distinct codec, so a subtree of clips sharing one
+    // source asks once.
+    const decodable = new Map<string | null | undefined, boolean>();
+    for (const { codec } of state.videos) {
+      if (!decodable.has(codec)) decodable.set(codec, await canDecodeVideoCodec(codec));
+    }
+    // A node can paint the same codec twice (its own asset and a fill); that
+    // is one finding, not two.
+    const reported = new Set<string>();
+    for (const { id, node, codec } of state.videos) {
+      if (decodable.get(codec)) continue;
+      if (reported.has(`${id}\0${codec}`)) continue;
+      reported.add(`${id}\0${codec}`);
+      state.issues.push({
+        code: "undecodable-video",
+        severity: "error",
+        node,
+        message: `No "${codec ?? "unknown"}" decoder on this machine — this node cannot render`,
+      });
+    }
 
     const issues: CheckIssue[] = [];
     if (window.end > window.start) {

--- a/apps/web/src/context/dapi/export.ts
+++ b/apps/web/src/context/dapi/export.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { canEncodeVideo } from "mediabunny";
-import { computeOutputSize } from "@diffusionstudio/encoder";
+import { computeOutputSize, resolveAudioCodec } from "@diffusionstudio/encoder";
 import { Computed, FrameRate, getParentNode, isScene, Source, Workarea } from "@diffusionstudio/runtime";
 
 import { renderOverlay, renderScene } from "@/context/render";
@@ -95,6 +95,26 @@ export function handleExport(session: () => EditorSession) {
       }
     }
 
+    // Same for audio, except that the codec asked for is a preference: AAC
+    // is the platform's encoder in WebCodecs and absent on Linux, so export
+    // with what this machine can encode into the container and echo that
+    // back, rather than failing a render that got as far as the audio track.
+    const audioEnabled = format === "ogg" || settings.audio?.enabled !== false;
+    let audio = settings.audio;
+    if (audioEnabled) {
+      const codec = await resolveAudioCodec(format, settings.audio?.codec, {
+        sampleRate: settings.audio?.sampleRate,
+        bitrate: settings.audio?.bitrate,
+      });
+      if (!codec) {
+        throw new Error(
+          `Cannot encode audio into ${format.toUpperCase()}. ` +
+            "Set another format, or turn audio off in the scene's export entry.",
+        );
+      }
+      audio = { ...settings.audio, codec };
+    }
+
     const workarea = scene.get(Workarea);
     const frames = workarea ? workarea.end - workarea.start : computed?.duration ?? 0;
     const duration = frames / (world.get(FrameRate)?.value || 30);
@@ -112,7 +132,7 @@ export function handleExport(session: () => EditorSession) {
       const result = await renderScene(engine, {
         scene,
         target: handle,
-        config: { ...settings, format },
+        config: { ...settings, format, audio },
         dir: project.dir(),
       });
       if (result.type === "canceled") throw new Error("Export canceled in the app");
@@ -128,7 +148,7 @@ export function handleExport(session: () => EditorSession) {
       source: target,
     });
 
-    const config: ExportSettings = { format, video: settings.video, audio: settings.audio };
+    const config: ExportSettings = { format, video: settings.video, audio };
     return {
       path: target,
       width: videoEnabled ? width : 0,

--- a/apps/web/src/context/dapi/media.ts
+++ b/apps/web/src/context/dapi/media.ts
@@ -10,7 +10,7 @@ import { composeSheet, planSheet, planSheetSizes, sheetTimecode } from '@diffusi
 import { assert } from '@/utils';
 import { startResumableSession, uploadResumableStream } from '@/lib/uploads';
 import { filmstripAsset, formatTimecode, getAssetFile, getLibrary, Project, transcodeForAnalysis, transcodeForTranscription, waveformAsset } from '@diffusionstudio/runtime';
-import { AssetLibrary, assetName, isAbsoluteSource, isUrlSource } from '@diffusionstudio/assets';
+import { AssetLibrary, assetName, canDecodeVideoTrack, isAbsoluteSource, isUrlSource } from '@diffusionstudio/assets';
 import { createProjectFS } from '@/projects/fs';
 
 import type { Accessor } from 'solid-js';
@@ -76,6 +76,7 @@ export function handleMediaProbe(resolve: ResolveAsset) {
           duration: await track.computeDuration(),
           ...stats,
           ...(track.isVideoTrack() && {
+            decodable: await canDecodeVideoTrack(track),
             codedWidth: track.codedWidth,
             codedHeight: track.codedHeight,
             displayWidth: track.displayWidth,

--- a/apps/web/src/context/export.tsx
+++ b/apps/web/src/context/export.tsx
@@ -6,7 +6,7 @@ import { createContext, useContext, onCleanup, onMount } from "solid-js";
 import { toast } from "somoto";
 import { canEncodeVideo } from "mediabunny";
 import { useWorld } from "@diffusionstudio/koota-solid";
-import { computeOutputSize } from "@diffusionstudio/encoder";
+import { computeOutputSize, resolveAudioCodec } from "@diffusionstudio/encoder";
 import { Computed, FrameRate, getActiveEntity } from "@diffusionstudio/runtime";
 import { assert, downloadObject, isInputTarget } from "@/utils";
 import { useEngineContext } from "@/engine";
@@ -71,6 +71,28 @@ export function ExportProvider(props: { children: JSX.Element }) {
         });
         return;
       }
+    }
+
+    // AAC is a platform encoder in WebCodecs (AudioToolbox on macOS, Media
+    // Foundation on Windows), so it is simply absent on Linux — pick what
+    // this browser can encode into the container and export with that, so
+    // the progress panel and the file agree on the codec.
+    const audioEnabled = format === "ogg" || config.audio?.enabled !== false;
+    if (audioEnabled) {
+      const codec = await resolveAudioCodec(format, config.audio?.codec, {
+        numberOfChannels: config.audio?.numberOfChannels,
+        sampleRate: config.audio?.sampleRate,
+        bitrate: config.audio?.bitrate,
+      });
+      if (!codec) {
+        toast.error("Export not supported", {
+          description:
+            `This browser cannot encode audio into ${format.toUpperCase()}. ` +
+            "Choose another format, or turn audio off.",
+        });
+        return;
+      }
+      config = { ...config, audio: { ...config.audio, codec } };
     }
 
     const name = project.name().replace(/\s+/g, "-").toLowerCase();

--- a/apps/web/src/engine/asset-actions.ts
+++ b/apps/web/src/engine/asset-actions.ts
@@ -6,7 +6,7 @@
 // mechanics live in @diffusionstudio/assets.
 
 import { toast } from "somoto";
-import { importFiles as importFilesInto, pickFiles, saveAssetAs as saveAs } from "@diffusionstudio/assets";
+import { importFiles as importFilesInto, assetName, canDecodeVideoCodec, pickFiles, saveAssetAs as saveAs } from "@diffusionstudio/assets";
 import { insertAsset } from "./insert-asset";
 import { forgetAssetMedia } from "./timeline/media";
 import { forgetAssetPeaks } from "./timeline/peaks";
@@ -35,6 +35,16 @@ export async function importFiles(library: AssetLibrary, files: ReadonlyArray<Fi
   }
   for (const { source, error } of report.failed) {
     toast.error(`Could not import ${source.split(/[\\/]/).pop()}`, { description: error.message });
+  }
+
+  // An asset the probe couldn't identify a decoder for imports fine and then
+  // renders blank; say so before the user builds around it. Decodability is
+  // asked of this machine — it is not written to the manifest.
+  for (const asset of report.assets) {
+    if (asset.type !== "VIDEO" || await canDecodeVideoCodec(asset.codec)) continue;
+    toast.warning(`Cannot decode ${assetName(asset)}`, {
+      description: `This machine has no ${asset.codec?.toUpperCase() ?? "video"} decoder, so the clip renders blank. Transcode it to H.264 (AVC) and import that instead.`,
+    });
   }
   return report.assets;
 }

--- a/apps/web/src/lib/desktop-app.ts
+++ b/apps/web/src/lib/desktop-app.ts
@@ -7,10 +7,10 @@ import { toast } from "somoto";
 import { track } from "@/lib/analytics";
 
 /**
- * Electron Forge only makes darwin artifacts, so releases are macOS-only, and
- * the DMG name is version-independent (see `MakerDMG` in `forge.config.ts`) —
- * which is what lets GitHub's `/releases/latest/download/` alias resolve to the
- * newest build.
+ * The download promos point at the macOS DMG, which is the release asset the
+ * Homebrew cask consumes too. Its name is version-independent (see `MakerDMG` in
+ * `forge.config.ts`) — which is what lets GitHub's `/releases/latest/download/`
+ * alias resolve to the newest build.
  */
 const DOWNLOAD_URL =
   "https://github.com/diffusionstudio/editor/releases/latest/download/Diffusion-Studio-arm64.dmg";

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "@electron-forge/maker-rpm": "^7.11.1",
         "@electron-forge/maker-zip": "^7.11.1",
         "@electron-forge/publisher-github": "^7.11.1",
+        "@reforged/maker-appimage": "^5.3.1",
         "@types/babel__core": "^7.20.5",
         "@types/node": "^24.10.1",
         "electron": "^43.1.1",
@@ -2892,6 +2893,37 @@
         "@octokit/openapi-types": "^12.11.0"
       }
     },
+    "node_modules/@reforged/maker-appimage": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@reforged/maker-appimage/-/maker-appimage-5.3.1.tgz",
+      "integrity": "sha512-lJqSZO+/qZmkarZ9pKZgE5DnZxuEvRe7JXupLo6YSTEOL+bkETthWP3XCLgAxLDsLCwPuPmF1tooYCt2dcIRCQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@electron-forge/maker-base": "^6.0.0 || ^7.0.0",
+        "@reforged/maker-types": "^2.2.0",
+        "@spacingbat3/lss": "^1.0.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=19.0.0 || ^18.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/SpacingBat3/ReForged?sponsor=1"
+      }
+    },
+    "node_modules/@reforged/maker-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@reforged/maker-types/-/maker-types-2.2.0.tgz",
+      "integrity": "sha512-14B5Tu6fG2AWgH+bdsfJaQkAi8Bc7YC8GmMuNEWCJupU9IhvKHrdte3GAncBYO10yqSbsQx7Pi9xpyveJ5vL+Q==",
+      "dev": true,
+      "license": "ISC",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/SpacingBat3/ReForged?sponsor=1"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
@@ -3570,6 +3602,13 @@
       "peerDependencies": {
         "solid-js": "^1.8.6"
       }
+    },
+    "node_modules/@spacingbat3/lss": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@spacingbat3/lss/-/lss-1.2.0.tgz",
+      "integrity": "sha512-aywhxHNb6l7COooF3m439eT/6QN8E/RSl5IVboSKthMHcp0GlZYMSoS7546rqDLmFRxTD8f1tu/NIS9vtDwYAg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.109.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,9 @@
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.11.1",
+        "@electron-forge/maker-deb": "^7.11.1",
         "@electron-forge/maker-dmg": "^7.11.1",
+        "@electron-forge/maker-rpm": "^7.11.1",
         "@electron-forge/maker-zip": "^7.11.1",
         "@electron-forge/publisher-github": "^7.11.1",
         "@types/babel__core": "^7.20.5",
@@ -786,6 +788,23 @@
         "node": ">= 16.4.0"
       }
     },
+    "node_modules/@electron-forge/maker-deb": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-deb/-/maker-deb-7.11.2.tgz",
+      "integrity": "sha512-MYSdCTsqzKNmsmaq7CIFh2kJdBWUZ4njxnVGrIRClzueVITk5Kots3+eQo+e5QQLvXTVn2XTNDc2nYjvtBh+Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/maker-base": "7.11.2",
+        "@electron-forge/shared-types": "7.11.2"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      },
+      "optionalDependencies": {
+        "electron-installer-debian": "^3.2.0"
+      }
+    },
     "node_modules/@electron-forge/maker-dmg": {
       "version": "7.11.2",
       "resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-7.11.2.tgz",
@@ -802,6 +821,23 @@
       },
       "optionalDependencies": {
         "electron-installer-dmg": "^5.0.1"
+      }
+    },
+    "node_modules/@electron-forge/maker-rpm": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-rpm/-/maker-rpm-7.11.2.tgz",
+      "integrity": "sha512-BEj/DcW6bSpmOyKUa3UsOgT7Hm3ZuP0Wa6OuQEunjxeCWn7yoDTDtjuYA0xRvzk+T4NCyDO3RBGjy6nYNSPU2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/maker-base": "7.11.2",
+        "@electron-forge/shared-types": "7.11.2"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      },
+      "optionalDependencies": {
+        "electron-installer-redhat": "^3.2.0"
       }
     },
     "node_modules/@electron-forge/maker-zip": {
@@ -4127,6 +4163,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/har-format": {
       "version": "1.2.16",
       "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
@@ -6210,6 +6257,242 @@
         "node": ">= 22.12.0"
       }
     },
+    "node_modules/electron-installer-common": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/electron-installer-common/-/electron-installer-common-0.10.4.tgz",
+      "integrity": "sha512-8gMNPXfAqUE5CfXg8RL0vXpLE9HAaPkgLXVoHE3BMUzogMWenf4LmwQ27BdCUrEhkjrKl+igs2IHJibclR3z3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@electron/asar": "^3.2.5",
+        "@malept/cross-spawn-promise": "^1.0.0",
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.0",
+        "glob": "^7.1.4",
+        "lodash": "^4.17.15",
+        "parse-author": "^2.0.0",
+        "semver": "^7.1.1",
+        "tmp-promise": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/electron-userland/electron-installer-common?sponsor=1"
+      },
+      "optionalDependencies": {
+        "@types/fs-extra": "^9.0.1"
+      }
+    },
+    "node_modules/electron-installer-common/node_modules/@malept/cross-spawn-promise": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/electron-installer-common/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-installer-debian": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/electron-installer-debian/-/electron-installer-debian-3.2.0.tgz",
+      "integrity": "sha512-58ZrlJ1HQY80VucsEIG9tQ//HrTlG6sfofA3nRGr6TmkX661uJyu4cMPPh6kXW+aHdq/7+q25KyQhDrXvRL7jw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "@malept/cross-spawn-promise": "^1.0.0",
+        "debug": "^4.1.1",
+        "electron-installer-common": "^0.10.2",
+        "fs-extra": "^9.0.0",
+        "get-folder-size": "^2.0.1",
+        "lodash": "^4.17.4",
+        "word-wrap": "^1.2.3",
+        "yargs": "^16.0.2"
+      },
+      "bin": {
+        "electron-installer-debian": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-installer-debian/node_modules/@malept/cross-spawn-promise": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/electron-installer-debian/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/electron-installer-debian/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/electron-installer-debian/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-installer-debian/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-installer-debian/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-installer-debian/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/electron-installer-debian/node_modules/yargs": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+      "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-installer-debian/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/electron-installer-dmg": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/electron-installer-dmg/-/electron-installer-dmg-5.0.1.tgz",
@@ -6230,6 +6513,172 @@
       },
       "optionalDependencies": {
         "appdmg": "^0.6.4"
+      }
+    },
+    "node_modules/electron-installer-redhat": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/electron-installer-redhat/-/electron-installer-redhat-3.4.0.tgz",
+      "integrity": "sha512-gEISr3U32Sgtj+fjxUAlSDo3wyGGq6OBx7rF5UdpIgbnpUvMN4W5uYb0ThpnAZ42VEJh/3aODQXHbFS4f5J3Iw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "@malept/cross-spawn-promise": "^1.0.0",
+        "debug": "^4.1.1",
+        "electron-installer-common": "^0.10.2",
+        "fs-extra": "^9.0.0",
+        "lodash": "^4.17.15",
+        "word-wrap": "^1.2.3",
+        "yargs": "^16.0.2"
+      },
+      "bin": {
+        "electron-installer-redhat": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-installer-redhat/node_modules/@malept/cross-spawn-promise": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/electron-installer-redhat/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/electron-installer-redhat/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/electron-installer-redhat/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-installer-redhat/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-installer-redhat/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-installer-redhat/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/electron-installer-redhat/node_modules/yargs": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+      "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-installer-redhat/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -7215,6 +7664,15 @@
         "node": ">= 12"
       }
     },
+    "node_modules/gar": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/gar/-/gar-1.0.4.tgz",
+      "integrity": "sha512-w4n9cPWyP7aHxKxYHFQMegj7WIAsL/YX/C4Bs5Rr8s1H9M1rNtRWRsw+ovYMkXDQ5S4ZbYHsHAPmevPjPgw44w==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/generate-function": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
@@ -7254,6 +7712,21 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-folder-size": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-2.0.1.tgz",
+      "integrity": "sha512-+CEb+GDCM7tkOS2wdMKTn9vU7DgnKUTuDlehkNJKNSovdCOVxs14OfKCk4cvSaR3za4gj+OBdl9opPN9xrJ0zA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "gar": "^1.0.4",
+        "tiny-each-async": "2.0.3"
+      },
+      "bin": {
+        "get-folder-size": "bin/get-folder-size"
       }
     },
     "node_modules/get-intrinsic": {
@@ -8681,6 +9154,14 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -11317,6 +11798,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-each-async": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-each-async/-/tiny-each-async-2.0.3.tgz",
+      "integrity": "sha512-5ROII7nElnAirvFn8g7H7MtpfV1daMcyfTGQwsn/x2VtyV+VPiO5CjReCJtWLvoKTDEDmZocf3cNPraiMnBXLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/tinyest": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyest/-/tinyest-0.3.2.tgz",
@@ -11395,6 +11884,28 @@
       },
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/tmp-promise/node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/tn1150": {

--- a/packages/assets/src/probe.ts
+++ b/packages/assets/src/probe.ts
@@ -5,9 +5,9 @@
 // What a file is: its MIME type and the type-specific metadata the runtime
 // needs before it can size or time an asset (dimensions, duration, tracks).
 
-import { ALL_FORMATS, BlobSource, Input, UrlSource } from 'mediabunny';
+import { ALL_FORMATS, BlobSource, canDecodeVideo, Input, UrlSource, VIDEO_CODECS } from 'mediabunny';
 
-import type { InputTrack } from 'mediabunny';
+import type { InputAudioTrack, InputTrack, InputVideoTrack, VideoCodec } from 'mediabunny';
 import type { Asset } from './types';
 
 export const DEFAULT_SEQUENCE_FPS = 30;
@@ -16,11 +16,65 @@ export const DEFAULT_SEQUENCE_FPS = 30;
 export type ProbeResult = Extract<
 	| { type: 'IMAGE'; width: number; height: number }
 	| { type: 'AUDIO'; duration: number; sampleRate: number; channels: number }
-	| { type: 'VIDEO'; duration: number; width: number; height: number; frameRate: number; bitRate: number; sampleRate?: number; channels?: number }
+	| { type: 'VIDEO'; duration: number; width: number; height: number; frameRate: number; bitRate: number; codec: string | null; sampleRate?: number; channels?: number }
 	| { type: 'TRANSCRIPT' }
 	| { type: 'SCRIPT' },
 	{ type: Asset['type'] }
 >;
+
+/**
+ * Whether this machine can decode a video track. WebCodecs gets
+ * decoders the platform actually has.
+ */
+export async function canDecodeVideoTrack(track: InputVideoTrack): Promise<boolean> {
+	if (typeof VideoDecoder === 'undefined') return true;
+	try {
+		return await track.canDecode();
+	} catch {
+		return true;
+	}
+}
+
+/**
+ * Whether this machine can decode an audio track. The counterpart of
+ * {@link canDecodeVideoTrack}, with the same fail-open rule: a host without
+ * WebCodecs is told nothing, so it calls nothing undecodable on a guess.
+ */
+export async function canDecodeAudioTrack(track: InputAudioTrack): Promise<boolean> {
+	if (typeof AudioDecoder === 'undefined') return true;
+	try {
+		return await track.canDecode();
+	} catch {
+		return true;
+	}
+}
+
+/**
+ * Whether this machine can decode a video codec, for a caller that has the
+ * codec but no track: an asset read back from the project manifest. The
+ * decodability of the machine that imported it is not written to the manifest
+ * (it is not a property of the file), so this is asked again wherever the
+ * answer matters.
+ *
+ * The three answers are told apart because they mean different things:
+ * `undefined` is an asset nobody has probed (a manifest written before the
+ * codec was recorded) and gets no claim; null is a probe that could not name
+ * the codec, and mediabunny can build no decoder config for such a track, so
+ * nothing decodes it; anything else is asked of WebCodecs. The same fail-open
+ * rule as {@link canDecodeVideoTrack} covers the rest: no WebCodecs, or a name
+ * this build does not know, and nothing is claimed.
+ */
+export async function canDecodeVideoCodec(codec: string | null | undefined): Promise<boolean> {
+	if (codec === undefined) return true;
+	if (codec === null) return false;
+	if (!(VIDEO_CODECS as readonly string[]).includes(codec)) return true;
+	if (typeof VideoDecoder === 'undefined') return true;
+	try {
+		return await canDecodeVideo(codec as VideoCodec);
+	} catch {
+		return true;
+	}
+}
 
 const TRANSCRIPT_TYPES = new Set(['application/json', 'application/x-subrip', 'text/vtt']);
 
@@ -140,10 +194,16 @@ export async function probeMedia(file: Blob, mimeType: string): Promise<ProbeRes
 
 		const videoTrack = await input.getPrimaryVideoTrack();
 		if (!videoTrack) throw new Error('Video track not found');
-		const stats = await videoTrack.computePacketStats();
+		const [stats, codec] = await Promise.all([
+			videoTrack.computePacketStats(),
+			videoTrack.getCodec(),
+		]);
 
 		return {
 			type: 'VIDEO',
+			// `null` and not `undefined`: a track whose codec the library could
+			// not name is a finding, and the manifest drops undefined fields.
+			codec: codec ?? null,
 			width: videoTrack.displayWidth,
 			height: videoTrack.displayHeight,
 			frameRate: stats.averagePacketRate,

--- a/packages/assets/src/types.ts
+++ b/packages/assets/src/types.ts
@@ -89,6 +89,7 @@ export interface VideoAsset extends AssetBase {
 	height: number;
 	frameRate: number;
 	bitRate: number;
+	codec?: string | null;
 	sampleRate?: number;
 	channels?: number;
 	transcript?: Transcript;

--- a/packages/encoder/src/codecs.ts
+++ b/packages/encoder/src/codecs.ts
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getFirstEncodableAudioCodec } from 'mediabunny';
+
+import { createOutputFormat } from './format';
+
+import type { AudioCodec } from 'mediabunny';
+import type { ContainerFormat } from './types';
+
+/** The parameters an audio codec has to be encodable at to be worth offering. */
+export type AudioEncodingOptions = {
+	numberOfChannels?: number;
+	sampleRate?: number;
+	bitrate?: number;
+};
+
+/** The audio codecs a container accepts, ordered by encoding preference. */
+export async function audioCodecsForFormat(format?: ContainerFormat): Promise<AudioCodec[]> {
+	const output = await createOutputFormat(format);
+	return output.getSupportedAudioCodecs();
+}
+
+/**
+ * The audio codec an export can actually be written with: the one asked for
+ * when the container takes it and this browser can encode it, else the
+ * container's next best encodable choice — `null` when there is none.
+ *
+ * Which codecs a browser can encode is not the same everywhere: WebCodecs
+ * hands AAC off to the platform (AudioToolbox on macOS, Media Foundation on
+ * Windows), so Chromium on Linux has no AAC encoder at all, while Opus is
+ * bundled everywhere. An mp4 asked for with AAC is therefore written with
+ * Opus there — which mp4 takes — rather than failing mid-encode.
+ */
+export async function resolveAudioCodec(
+	format?: ContainerFormat,
+	requested?: AudioCodec,
+	options?: AudioEncodingOptions,
+): Promise<AudioCodec | null> {
+	const supported = await audioCodecsForFormat(format);
+
+	// The asked-for codec goes first, the container's own preference order
+	// (aac, opus, mp3, …, pcm) decides the rest.
+	const candidates = requested && supported.includes(requested)
+		? [requested, ...supported.filter((codec) => codec !== requested)]
+		: supported;
+
+	return getFirstEncodableAudioCodec(candidates, options);
+}

--- a/packages/encoder/src/encoder.ts
+++ b/packages/encoder/src/encoder.ts
@@ -23,6 +23,7 @@ import {
 } from '@diffusionstudio/runtime';
 
 import { TargetBuffer } from './buffer';
+import { resolveAudioCodec } from './codecs';
 import { createOutputFormat } from './format';
 import { computeOutputSize, createRenderEventDetail } from './utils';
 
@@ -96,7 +97,7 @@ export async function createEncoder(world: World, config: EncoderConfig) {
 	const sampleRate = config.audio?.sampleRate ?? 48000;
 	const audioBitrate = config.audio?.bitrate ?? 128e3;
 	const videoBitrate = config.video?.bitrate ?? 10e6;
-	const audioCodec = config.audio?.codec ?? 'aac';
+	const requestedAudioCodec = config.audio?.codec ?? 'aac';
 	const videoCodec = config.video?.codec ?? 'avc';
 	const containerFormat = config.format ?? 'mp4';
 	const resolution = config.video?.resolution ?? 1080;
@@ -115,6 +116,24 @@ export async function createEncoder(world: World, config: EncoderConfig) {
 			'Choose a lower resolution, a lower bitrate, or another codec.',
 		);
 	}
+
+	// Same, for audio: what a browser can encode depends on the platform
+	// underneath it (no AAC encoder on Linux, where WebCodecs has no system
+	// one to hand it to), so the codec asked for is only a preference — the
+	// container's next encodable choice is written instead of failing.
+	const audioCodec = audioEnabled
+		? await resolveAudioCodec(containerFormat, requestedAudioCodec, {
+			numberOfChannels,
+			sampleRate,
+			bitrate: audioBitrate,
+		})
+		: requestedAudioCodec;
+
+	assert(
+		audioCodec,
+		`This browser cannot encode audio into ${containerFormat.toUpperCase()}. ` +
+		'Choose another format, or turn audio off.',
+	);
 
 	const canvas = world.get(RenderSurface)?.canvas;
 	assert(canvas instanceof HTMLCanvasElement, 'The capture world has no canvas to draw into');
@@ -146,7 +165,7 @@ export async function createEncoder(world: World, config: EncoderConfig) {
 
 	// Set up mediabunny output
 	const buffer = await TargetBuffer.create(config.target);
-	const format = await createOutputFormat(buffer, config.format);
+	const format = await createOutputFormat(config.format, { fastStart: buffer.fastStart });
 	const output = new Output({ format, target: buffer.target });
 
 	if (config.comment) {

--- a/packages/encoder/src/format.ts
+++ b/packages/encoder/src/format.ts
@@ -2,13 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import type { TargetBuffer } from './buffer';
 import type { ContainerFormat } from './types';
 
 /**
- * Lazily imports the output format based on the format specified
+ * Lazily imports the output format based on the format specified.
+ *
+ * `fastStart` is the ISOBMFF option the target dictates (see `TargetBuffer`);
+ * it is nothing to a query of what the container supports, so it is optional.
  */
-export async function createOutputFormat(buffer: TargetBuffer, format?: ContainerFormat) {
+export async function createOutputFormat(
+  format?: ContainerFormat,
+  options?: { fastStart?: false | 'in-memory' },
+) {
   if (format == 'webm') {
     const { WebMOutputFormat } = await import('mediabunny');
     return new WebMOutputFormat();
@@ -20,6 +25,6 @@ export async function createOutputFormat(buffer: TargetBuffer, format?: Containe
     return new MovOutputFormat();
   } else {
     const { Mp4OutputFormat } = await import('mediabunny');
-    return new Mp4OutputFormat({ fastStart: buffer.fastStart });
+    return new Mp4OutputFormat({ fastStart: options?.fastStart ?? false });
   }
 }

--- a/packages/encoder/src/index.ts
+++ b/packages/encoder/src/index.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export * from './buffer';
+export * from './codecs';
 export * from './contact-sheet';
 export * from './encoder';
 export * from './format';

--- a/packages/encoder/src/interfaces.ts
+++ b/packages/encoder/src/interfaces.ts
@@ -31,7 +31,9 @@ export interface AudioConfig {
 	bitrate?: number;
 
 	/**
-	 * Defines the codec to use for the audio
+	 * Defines the codec to use for the audio. A preference rather than a
+	 * demand: a codec the container or this browser cannot encode is replaced
+	 * with the container's next encodable choice (see `resolveAudioCodec`).
 	 * @default 'aac'
 	 */
 	codec?: AudioCodec;

--- a/packages/runtime/src/media/transcode.ts
+++ b/packages/runtime/src/media/transcode.ts
@@ -7,6 +7,7 @@
 // draw into an OffscreenCanvas, so everything here is worker-capable.
 
 import { ALL_FORMATS, AudioSampleSink, BlobSource, BufferTarget, CanvasSink, Conversion, Input, InputAudioTrack, Mp4OutputFormat, OggOutputFormat, Output, StreamTarget } from 'mediabunny';
+import { canDecodeAudioTrack, canDecodeVideoTrack } from '@diffusionstudio/assets';
 
 import { assert } from '../utils/assert';
 import { formatTimestamp } from '../utils/time';
@@ -179,6 +180,11 @@ export async function filmstripAsset(asset: Asset, options?: PreviewOptions): Pr
 async function renderFilmstrip(asset: VideoAsset, input: Input, window: TimeWindow | undefined, scale: number): Promise<RenderedPreview> {
 	const videoTrack = await input.getPrimaryVideoTrack();
 	assert(videoTrack, "Video track not found");
+	const videoCodec = await videoTrack.getCodec();
+	assert(
+		await canDecodeVideoTrack(videoTrack),
+		`This machine cannot decode the "${videoCodec ?? "unknown"}" video codec, so no filmstrip can be rendered.`,
+	);
 	const { start: windowStart, duration } = resolveWindow(asset.duration, window);
 	const aspect = asset.width / asset.height;
 	const frameRate = asset.frameRate;
@@ -271,9 +277,10 @@ export async function waveformAsset(asset: Asset, options?: PreviewOptions): Pro
 async function renderWaveform(asset: VideoAsset | AudioAsset, input: Input, window: TimeWindow | undefined, scale: number): Promise<RenderedWaveform> {
 	const audioTrack = await input.getPrimaryAudioTrack();
 	assert(audioTrack, "No audio track found, so no waveform can be rendered.");
+	const audioCodec = await audioTrack.getCodec();
 	assert(
-		await audioTrack.canDecode(),
-		`This browser's audio decoder can't handle the "${audioTrack.getCodec() ?? "unknown"}" codec, so no waveform can be rendered.`,
+		await canDecodeAudioTrack(audioTrack),
+		`This machine cannot decode the "${audioCodec ?? "unknown"}" audio codec, so no waveform can be rendered.`,
 	);
 	const { start: windowStart, duration } = resolveWindow(asset.duration, window);
 	const rulerFrameRate = asset.type === "VIDEO" ? asset.frameRate : AUDIO_RULER_FRAME_RATE;

--- a/packages/runtime/src/media/video.ts
+++ b/packages/runtime/src/media/video.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { BlobSource, ALL_FORMATS, Input, InputVideoTrack, EncodedPacketSink, EncodedPacket, CanvasSink, type WrappedCanvas } from 'mediabunny';
+import { canDecodeVideoTrack } from '@diffusionstudio/assets';
 
 import { AssetId, VideoDecoderHandle, Mode } from '../traits';
 import { assert } from '../utils/assert';
@@ -532,10 +533,17 @@ class VideoDecoderQueue {
 	}
 
 	public async init(track: InputVideoTrack) {
-		this.config = await track.getDecoderConfig();
-		assert(this.config, 'Failed to get decoder config from track');
-		const support = await VideoDecoder.isConfigSupported(this.config);
-		assert(support.supported, 'Decoder config not supported');
+		const config = await track.getDecoderConfig();
+		assert(config, 'Failed to get decoder config from track');
+		this.config = config;
+		const [codec, support] = await Promise.all([
+			track.getCodec(),
+			VideoDecoder.isConfigSupported(config).catch(() => null),
+		]);
+		assert(
+			support?.supported,
+			`This machine cannot decode the "${codec ?? config.codec}" video codec, so no frame of it can be shown.`,
+		);
 	}
 
 	private ensureDecoder(packet: EncodedPacket) {
@@ -599,6 +607,7 @@ export class VideoExporter {
 	private iterator: AsyncGenerator<WrappedCanvas, void, unknown> | null = null;
 	private currentCanvas: WrappedCanvas | null = null;
 	private firstTimestamp: number = 0;
+	private undecodable: Error | null = null;
 
 	public constructor(asset: VideoAsset) {
 		this.asset = asset;
@@ -615,6 +624,17 @@ export class VideoExporter {
 			// timestamp) doesn't offset every exported frame relative to the audio.
 			this.firstTimestamp = Math.max(0, await track.getFirstTimestamp() ?? 0);
 			this.canvasSink = new CanvasSink(track, { poolSize: 2 });
+			// Ask the track, not the asset: decodability belongs to the machine,
+			// and the manifest does not carry it.
+			const [codec, decodable] = await Promise.all([
+				track.getCodec(),
+				canDecodeVideoTrack(track),
+			]);
+			if (!decodable) {
+				this.undecodable = new Error(
+					`This machine cannot decode the "${codec ?? 'unknown'}" video codec, so no frame of ${this.asset.path} can be rendered.`,
+				);
+			}
 		} catch (e) {
 			console.error('Error initializing video exporter', e);
 			this.errored = true;
@@ -624,6 +644,7 @@ export class VideoExporter {
 	public async seekTo(frame: number, frameRate: number): Promise<void> {
 		await this.initialized;
 
+		if (this.undecodable) throw this.undecodable;
 		if (this.errored || !this.canvasSink) return;
 
 		const targetFrame = Math.round((frame / frameRate) * this.asset.frameRate);

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,0 +1,63 @@
+# Maintainer: Diffusion Studio Inc. <support@diffusion.studio>
+#
+# Packages the prebuilt app that `electron-forge package` leaves in
+# apps/desktop/out into an Arch Linux package. Adapted from the PKGBUILD in
+# https://github.com/diffusionstudio/editor/pull/42 by @Tsurgcom; the launcher
+# shim it carried is gone because the Linux executable is now renamed to
+# `diffusion-studio`, so /usr/bin can link straight to it.
+#
+# apps/desktop/scripts/make-arch.mjs stages this file and the source tarball,
+# substituting __VERSION__.
+pkgname=diffusion-studio
+pkgver=__VERSION__
+pkgrel=1
+pkgdesc="Edit videos with coding agents, and refine any output in a full editing environment"
+arch=('x86_64')
+url="https://diffusion.studio"
+license=('MPL-2.0')
+# Electron ships pre-stripped release binaries; stripping them again only
+# produces gdb-add-index noise and an empty -debug package.
+options=(!strip !debug)
+depends=(
+  'gtk3'
+  'nss'
+  'alsa-lib'
+  'at-spi2-core'
+  'libxss'
+  'libxtst'
+  'libxcursor'
+  'libxrandr'
+  'libxcomposite'
+  'libxdamage'
+  'libxfixes'
+  'mesa'
+  'ca-certificates'
+)
+optdepends=(
+  'xdg-utils: open exported files and diffusion:// links'
+  'fontconfig: font discovery for `dapi fonts` and the editor'
+)
+# Built from the local forge output, staged next to this file rather than
+# fetched from a URL.
+source=("diffusion-studio-$pkgver-linux-x64.tar.gz")
+sha256sums=('SKIP')
+
+package() {
+  cd "$srcdir/diffusion-studio-$pkgver-linux-x64"
+
+  install -d "$pkgdir/usr/lib/$pkgname"
+  cp -a . "$pkgdir/usr/lib/$pkgname/"
+
+  # Chromium's setuid sandbox helper, matching what the deb and rpm ship. It is
+  # only used where unprivileged user namespaces are unavailable.
+  chmod 4755 "$pkgdir/usr/lib/$pkgname/chrome-sandbox"
+
+  install -d "$pkgdir/usr/bin"
+  ln -s "/usr/lib/$pkgname/$pkgname" "$pkgdir/usr/bin/$pkgname"
+  # The dapi CLI ships inside the app's resources; a package can put it on PATH
+  # directly, so the in-app installer is only needed for the AppImage and ZIP.
+  ln -s "/usr/lib/$pkgname/resources/cli/bin/dapi" "$pkgdir/usr/bin/dapi"
+
+  install -Dm644 "$pkgname.desktop" "$pkgdir/usr/share/applications/$pkgname.desktop"
+  install -Dm644 "$pkgname.png" "$pkgdir/usr/share/pixmaps/$pkgname.png"
+}

--- a/packaging/linux/diffusion-studio.desktop
+++ b/packaging/linux/diffusion-studio.desktop
@@ -1,0 +1,17 @@
+[Desktop Entry]
+Version=1.5
+Type=Application
+Name=Diffusion Studio
+GenericName=Video Editor
+Comment=Edit videos with coding agents, and refine any output in a full editing environment
+Exec=diffusion-studio %U
+Icon=diffusion-studio
+Terminal=false
+StartupNotify=true
+# Groups the window with its launcher: Chromium reports the app name, not the
+# renamed executable.
+StartupWMClass=Diffusion Studio
+Categories=AudioVideo;Video;
+# Registers `diffusion://`, which is how the auth and checkout deep links come
+# back to the app - the same job `packagerConfig.protocols` does on macOS.
+MimeType=x-scheme-handler/diffusion;

--- a/patches/electron-installer-redhat+3.4.0.patch
+++ b/patches/electron-installer-redhat+3.4.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/electron-installer-redhat/resources/spec.ejs b/node_modules/electron-installer-redhat/resources/spec.ejs
+index e07a8a3..3f9c2a9 100644
+--- a/node_modules/electron-installer-redhat/resources/spec.ejs
++++ b/node_modules/electron-installer-redhat/resources/spec.ejs
+@@ -24,7 +24,7 @@ print('\n\n\n') }
+ 
+ %>%install
+ mkdir -p %{buildroot}/usr/
+-cp <%= process.platform === 'darwin' ? '-R' : '-r' %> usr/* %{buildroot}/usr/
++cp <%= process.platform === 'darwin' ? '-R' : '-r' %> %{_topdir}/BUILD/usr/. %{buildroot}/usr/
+ 
+ 
+ %files

--- a/reference/check.md
+++ b/reference/check.md
@@ -1,6 +1,6 @@
 # `dapi check <id>`
 
-Checks a node's subtree for obvious structural mistakes, without rendering: spans of the node's play window where **no visual is scheduled** (likely black frames), children that never become visible, zero-duration or fully transparent nodes, and assets that failed to load or generate. Alongside the issues it reports subtree stats — node count by kind, nesting depth, and played duration — so it doubles as a quick structural summary of a scene.
+Checks a node's subtree for obvious structural mistakes, without rendering: spans of the node's play window where **no visual is scheduled** (likely black frames), children that never become visible, zero-duration or fully transparent nodes, and assets that failed to load, failed to generate, or that this machine has no decoder for — plus subtree stats (node count by kind, nesting depth, and played duration) — so it doubles as a quick structural summary of a scene.
 
 The analysis is structural, from the resolved timeline alone, so it is instant and costs no credits — and it can only say *nothing is scheduled*, not *the frame is black*. A scheduled clip can still render black (dark footage, content smaller than the canvas, a transparent asset); confirm suspicious spans visually with [`capture`](./capture.md) at a time inside the range.
 
@@ -25,7 +25,7 @@ One JSON object:
     duration: number;                 // seconds the checked node plays (its workarea, when one is set)
   };
   issues: Array<{
-    code: "black-frames" | "no-visuals" | "never-visible" | "zero-duration" | "transparent" | "source-error";
+    code: "black-frames" | "no-visuals" | "never-visible" | "zero-duration" | "transparent" | "source-error" | "undecodable-video";
     severity: "error" | "warning";
     message: string;
     node?: string;                    // source stamp of the offending node; absent for subtree-wide issues
@@ -44,6 +44,7 @@ One JSON object:
 | `zero-duration` | warning | A node that spans no frames |
 | `transparent` | warning | A node with static opacity 0 (nodes with keyframes are given the benefit of the doubt) |
 | `source-error` | error | An asset that failed to load or generate, with the failure message |
+| `undecodable-video` | error | A video node — or a node a `<videoPaint>` fills with footage — whose codec this machine has no decoder for (an HEVC source without a platform decoder, or one the library could not identify at all); it resolves and imports fine and renders nothing |
 
 ## Exit code
 

--- a/reference/export.md
+++ b/reference/export.md
@@ -30,7 +30,7 @@ The scene's entry under `diffusion.export.<id>` in the project's `package.json`:
         },
         "audio": {
           "enabled": true,
-          "codec": "aac",                   // aac | opus
+          "codec": "aac",                   // aac | opus — a preference: see below
           "sampleRate": 48000,
           "bitrate": 128000
         }
@@ -41,6 +41,8 @@ The scene's entry under `diffusion.export.<id>` in the project's `package.json`:
 ```
 
 Every field is optional; the encoder fills what the entry leaves out. A scene without an entry exports with the defaults — 1080p H.264 MP4 with AAC audio, the app's default template. `resolution` scales the scene uniformly until its shorter side reaches the number, so a portrait 1080×1920 scene at `2160` encodes as 2160×3840.
+
+The audio `codec` is a preference rather than a demand: which codecs a machine can encode is not the same everywhere — AAC is the platform's encoder in WebCodecs (AudioToolbox on macOS, Media Foundation on Windows) and absent on Linux, while Opus is bundled everywhere — so a codec this machine cannot encode into the container is replaced with the container's next encodable choice. The echoed `config` names the codec the file was actually written with.
 
 ## Output
 

--- a/reference/fonts.md
+++ b/reference/fonts.md
@@ -1,6 +1,6 @@
 # `dapi fonts`
 
-Lists local fonts available on this machine. macOS only. Does not require the app to be running. Font families listed here are valid `fontFamily` values on [`<text>`](./jsx/text.md).
+Lists local fonts available on this machine. macOS and Linux (through fontconfig — `fc-list`). Does not require the app to be running. Font families listed here are valid `fontFamily` values on [`<text>`](./jsx/text.md).
 
 ## Options
 

--- a/reference/jsx/fonts.md
+++ b/reference/jsx/fonts.md
@@ -1,6 +1,6 @@
 # Fonts
 
-Both text paths draw with fonts **installed on the machine**. Discover what is available with [`dapi fonts`](../fonts.md) (filter by family, weight, or style); the active project's families are also on [`dapi context`](../context.md) as `fontFamilies`. macOS resolves these families for both the native renderer and the browser, so there is nothing to bundle or load.
+Both text paths draw with fonts **installed on the machine**. Discover what is available with [`dapi fonts`](../fonts.md) (filter by family, weight, or style); the active project's families are also on [`dapi context`](../context.md) as `fontFamilies`. The system resolves these families for both the native renderer and the browser — CoreText on macOS, fontconfig on Linux — so there is nothing to bundle or load.
 
 ## Native `<text>`
 

--- a/reference/media/probe.md
+++ b/reference/media/probe.md
@@ -10,6 +10,8 @@ Reads the container and per-track technical metadata of an asset; like `ffprobe`
 
 One JSON object. The shape is **not yet stable**: it reports whatever mediabunny surfaces about the container and its tracks. Packet stats (frame rate, bitrate, packet count) are estimated from a leading sample of packets, so they are fast but approximate. Assets mediabunny can't demux (images, transcripts) don't error; they report file-level info only, with `format: null` and no tracks.
 
+Each video track carries `decodable`: whether this machine's decoder can play that codec. WebCodecs answers for the decoders the platform actually has, so an `hevc` track is `false` wherever no platform HEVC decoder is available (typically Linux). A clip like this could be imported but renders nothing wherever it is used. Audio tracks do not report it; see `waveform` for the audio decoder.
+
 ## Errors
 
 Exits non-zero if the path can't be resolved.

--- a/reference/open.md
+++ b/reference/open.md
@@ -44,5 +44,6 @@ With no path, nothing: exit code `0` says the app is up.
 ## Errors
 
 - The path exists but is not a folder.
-- Off macOS, the app cannot be launched; the command then requires it to
-  already be running.
+- The app could not be launched — on Linux, when neither its executable nor a
+  handler for the `diffusion://` scheme is installed, and on every other
+  platform than macOS; the command then requires the app to already be running.


### PR DESCRIPTION
Linux support with fixes and packages like .appimage


<details><summary>Claude AI Pull Request </summary>
<p>

Linux support in six commits that can be taken separately. Built, packaged, launched and driven on Linux (KDE Plasma 6.7 Wayland, NVIDIA, Chromium/Electron with no system AAC encoder); every change is either platform-gated or a strict superset, so macOS behaviour is unchanged.

## 1. `fix(export)`: resolve the audio codec against what the platform can encode

The bug that started this: **every mp4 export fails on Linux.** Video is fine — Chromium's bundled OpenH264 encodes AVC — but every template in `export-templates.ts` asks for `audio: { codec: "aac" }` and the encoder took that as a demand. In WebCodecs, AAC is the *platform's* encoder (AudioToolbox on macOS, Media Foundation on Windows), so Chromium on Linux has none, and the export dies after the video track has already started.

The requested codec is now a preference. New `resolveAudioCodec(format, requested, options)` in `@diffusionstudio/encoder` keeps it when the container takes it **and** the browser can encode it, otherwise picks the container's next encodable choice — Opus, which mp4 accepts and Chromium bundles everywhere. Resolved at all three places an export starts:

- `context/export.tsx` (⌘E / the panel) — before the save picker, so the progress overlay names what is actually written
- `context/dapi/export.ts` (`dapi export`) — before the render, so the echoed `config` is truthful
- `packages/encoder/src/encoder.ts` — last line of defence, so a project authored on macOS with `"codec": "aac"` in `package.json` exports on Linux unedited

The audio picker now offers only codecs this machine can encode into the chosen container. `createOutputFormat` lost its `TargetBuffer` parameter and takes `{ fastStart }`, so container support is queryable without a write target.

Verified in a real Chromium: `canEncodeAudio('aac')` → `false`, `resolveAudioCodec('mp4','aac')` → `opus`, and an mp4 muxed through the same `AudioSampleSource`/`CanvasSource` path reads back as `avc` + `opus` with decodable audio. Where AAC exists it is encodable, so it stays what gets used.

## 2. `feat(desktop)`: package and run on Linux

`makers` had only `MakerZIP(['darwin'])` and the DMG, so a Linux checkout could be `package`d but never `make`d. Adds `MakerDeb` and `MakerRpm` for `['linux']` plus a Linux ZIP, and scopes the DMG to `['darwin']`.

The Linux build renames the executable to `diffusion-studio`: electron-packager keeps the space from `name`, fine inside a `.app` but not for the binary the packages symlink into `/usr/bin`. Gated to Linux, so macOS still produces `Contents/MacOS/Diffusion Studio` — the name the CLI wrapper and the signing pass both address.

`setupAppMenu()` returned early off darwin, so "Install dapi Command Line Tool…" was unreachable behind Electron's stock menu; there is now a non-macOS template carrying it under File, with no AppKit-only roles.

**No ozone/Wayland flag, and that is deliberate.** I tried `--ozone-platform-hint=auto` first, since the Wayland/Vulkan line in the log invites it. It makes the packaged app unusable here: the window comes up blank or with every glyph missing, while a DevTools capture of the same renderer is pixel-correct — the renderer paints and Wayland presentation drops it (`'--ozone-platform=wayland' is not compatible with Vulkan`). Chromium's XWayland default renders correctly. Electron already reads `ELECTRON_OZONE_PLATFORM_HINT=auto` from the environment, so anyone whose driver handles native Wayland can opt in; the code says why it is not the default.

`release.yml` gains a `publish-linux` job on `ubuntu-latest` (installing `zip`, `dpkg-dev`, `fakeroot`, `rpm`, `squashfs-tools`) so artifacts land on the same draft release. It carries no Apple secrets. **Drop this hunk if you'd rather not build Linux in CI yet.**

Left alone deliberately: `build-native.mjs` exiting 0 off darwin (AppKit addon), `projects.ts`'s `fileProviderDomains` returning `[]` off darwin (File Provider is a macOS service), and `update-electron-app`, which already no-ops on Linux.

## 3. `feat(cli)`: make dapi work on Linux

- **`dapi open` could not launch the app** — `launchApp` shelled out to `open -a` behind a darwin gate. Linux now spawns the executable the packaged wrapper points at (`DIFFUSION_APP_PATH`), then one on `PATH`, then hands `diffusion://` to `xdg-open`; failure still falls through to the socket and its existing error.
- **`dapi fonts` hard-failed off darwin** — now enumerates through fontconfig, mapping `fc-list`'s weight axis onto CSS weights and collapsing the one-line-per-file listing into families. 304 families here, filters intact, and the `local()` sources it emits load in Chromium via `FontFace`. Without fontconfig it says so and names the package.
- **The staged `cli/bin/dapi` wrapper hardcoded `$DIR/../../../MacOS/Diffusion Studio`** — it now picks the layout it sits in: the bundle path on macOS, byte for byte as before, or the flat packager tree beside `resources/`. Tested against both simulated layouts, the symlink-on-PATH case, and the missing-executable error.
- **The in-app installer** linked into `/usr/local/bin` behind an `osascript` admin prompt; on Linux it links `~/.local/bin`, which the user owns, so nothing is elevated.

## 4. `feat(desktop)`: build an AppImage as well

deb and rpm cover Debian/Ubuntu and Fedora; everywhere else there was nothing to hand a user. Adds `@reforged/maker-appimage` (Forge has no first-party AppImage maker) — one executable file, no root, no package manager. Both makers now set `bin` explicitly, because it defaults to the sanitized package name (`diffusionstudio-desktop`) rather than what electron-packager emits, and the AppImage build fails outright without it.

Flatpak is not here on purpose: the sandbox fights what this app does — editing arbitrary project folders, spawning agent CLIs and `esbuild`/Babel, putting `dapi` on `PATH`. Making it work means `--filesystem=host` plus no CLI install, a worse deal than the AppImage. Happy to add it if you disagree.

## 5. `feat(desktop)`: package for Arch, and fix what a real package build hits

Dry-running the makers against the packaged tree — rather than trusting their config — turned up two builds that could never have succeeded, and comparing notes with #42 turned up a third:

- **The deb had no `Maintainer`,** one of the five fields dpkg-deb requires. It defaults to `package.json`'s `author`, which this workspace does not set, and the control template omits the field silently — the release job would have failed on its first run. Caught by staging the deb tree with `electron-installer-debian`'s own installer class and reading the rendered `DEBIAN/control`, no `dpkg-deb` needed.
- **`@electron-forge/maker-rpm` is broken on rpm ≥ 4.20.** electron-installer-redhat 3.4.0 writes a spec whose `%install` runs `cp -r usr/*` relative to the build directory, which rpm 4.20 moved — it fails on Fedora 41+ and recent Debian/Ubuntu (electron-userland/electron-installer-redhat#343, electron/forge#3701, both open). **Diagnosed in #42.** Fixed here through the `patch-package` setup this repo already runs, so the maker keeps generating dependencies and metadata instead of the spec being hand-maintained.
- **MakerZIP shells out to `zip`** (`cross-zip`), which is not installed everywhere — `spawn zip ENOENT` here. Named in the README with the other per-maker tools and installed in CI.

**Arch Linux support comes from #42.** Arch has no Forge maker, so a script stages the forge output and runs `makepkg`, with a `publish-arch` container job. Adapted: the launcher shim that PR needed is gone, because the executable is renamed and `/usr/bin` can link straight to it; their `ln -s … resources/cli/bin/dapi` is kept, since a package *can* put `dapi` on PATH.

All four formats now install **one** desktop entry, in `packaging/linux/`, so the makers and the PKGBUILD cannot drift. It registers `x-scheme-handler/diffusion` — how the auth and checkout deep links come back to the app, the job `packagerConfig.protocols` does on macOS.

## 6. `fix(cli)`: install a working dapi from an AppImage, and stop the app inheriting node mode

Two bugs found by installing the CLI from a real AppImage and then quitting it, which is what a user does:

- **The install wrote a symlink into the image's mount.** That mount lives under `/tmp` only while the app runs, with a fresh random name each launch, so the link dangled the moment the app quit. The image *file* is stable and can run the CLI on its own Electron in node mode, so the install now writes a wrapper that does exactly that — the image mounts itself for the duration of each call. The path inside the mount is read from the running process, not assumed, since the maker decides the layout.
- **`dapi open` could never launch the app from any packaged install, deb and rpm included.** The wrapper runs the CLI with `ELECTRON_RUN_AS_NODE=1` and the spawned app inherited it, so it started with no main script and exited without a window. Earlier tests missed this because the launch target was a shell stub, which ignores the variable. `spawnDetached` now drops it, along with the AppImage variables.

## Relationship to #42 (@Tsurgcom)

#42 landed first and covers packaging: deb, rpm, zip, AppImage and Arch. This PR overlaps it and goes wider (the export bug, the CLI, the app menu), so rather than leave two competing branches I folded the parts of #42 that are better than what I had into this one, credited on the commit (`Co-authored-by: Tsurg`). **Maintainers: prefer #42's authorship where the work is theirs — I'm happy to rebase this onto it instead if that merges more easily.**

Taken from #42: **Arch support** (adapted as above), **the rpm ≥ 4.20 diagnosis** — which would have broken my rpm build in CI and I had missed entirely — and **`StartupWMClass`** in the desktop entry.

Kept from this branch: **makers over hand-written specs** for deb/rpm/AppImage, so dependency lists, `chrome-sandbox` 4755, icons and lintian overrides come from the makers (only Arch, which has no maker, is a script); **`executableName: 'diffusion-studio'`** instead of working around the space per format; **one desktop entry for all four formats** (in #42 the rpm and Arch entries register `diffusion://` and the deb's generated entry does not, which is the difference between deep links working and silently doing nothing on Debian/Ubuntu); and **no ozone flag**.

Two notes sent back to #42: the missing `MimeType` above, and that its `publish-arch` job runs as root in `archlinux:latest` while `makepkg` refuses to run as root — the version here creates a `builder` user and runs the step under `sudo -u builder`.

## What was actually built and run

| Artifact | Result |
|---|---|
| `Diffusion Studio-linux-x64` (electron-packager) | Launches; renders correctly; new File/Edit/View/Window menu; executable is `diffusion-studio` |
| Shipped `resources/cli/bin/dapi` | `--version` and `fonts` run on the packaged Electron in node mode |
| `Diffusion Studio-0.204.1-x64.AppImage` (128 MB) | Launches from its mount, renders correctly, entry carries `MimeType=x-scheme-handler/diffusion`. Install-CLI driven through the real `cli:install` channel, then the app quit: the wrapper survives, `dapi --version` → `0.204.1`, `dapi fonts` works, and `dapi open` **relaunches the AppImage** and opens the project |
| `diffusion-studio-0.204.1-1-x86_64.pkg.tar.zst` (Arch) | Built with `makepkg`; root-owned, `chrome-sandbox` `-rwsr-xr-x`, both `/usr/bin` symlinks, shared desktop entry, `dapi --version` → `0.204.1` from the extracted tree |
| `.deb` / `.rpm` | **Not built here** — no `dpkg-deb`/`rpmbuild` and no root to install them. `DEBIAN/control` and the `.spec` are verified by rendering them through the makers' own code; CI is the first archive build |

**Absent-dependency paths, tested rather than assumed:** no FUSE/`fusermount` → the AppImage prints the FUSE hint and `--appimage-extract-and-run` starts the app; no `fontconfig` → `dapi fonts` names the package to install, exit 1; no `xdg-open` with the app down → `dapi open` says "launch the app first", exit 1, no crash and no false success. GTK3/NSS/libcups are declared as deb `Depends` and Arch `depends`. The binary floor is Electron's, not this host's: the executable references at most `GLIBC_2.25`, so glibc ≥ 2.25 (Ubuntu 18.04+, Debian 10+, RHEL 8+). `~/.local/bin` is on PATH on Debian and Fedora but not Arch, so the install dialog only claims `dapi` is ready when the link target is on the session PATH, and otherwise names the directory to add.

## Checks

`npm run check` and `npm run lint` pass for every workspace touched (`apps/web`, `apps/cli`, `apps/desktop`, `packages/encoder`). Two pre-existing failures in this environment are unrelated and untouched: `packages/assets/src/browser.ts` `showSaveFilePicker` (present before these commits) and `examples/` missing optional deps (`three`, `redraw`, `@typegpu/noise`).

Not covered: Windows. The AAC resolution helps it for free, but nothing else here was built or tested there.

</p>
</details> 



