### PR TITLE
fix: clamp clip drag to timeline start (0s)

### DIFF
--- a/apps/web/src/engine/timeline/drag.ts
+++ b/apps/web/src/engine/timeline/drag.ts
@@ -116,7 +116,7 @@ export function applyClipDrag(
 	const snap = findSnapDelta(world, resolution, offset);
 	if (snap) surface.snapX = framesToPixels(snap.frame, resolution);
 
-	moveEntityTo(world, entity, origin.start + offset - (snap?.delta ?? 0));
+	moveEntityTo(world, entity, Math.max(0, origin.start + offset - (snap?.delta ?? 0)));
 }
 
 /** Notes where `entity`'s edges are, so a trim can be measured from them. */


### PR DESCRIPTION
## Root cause
`applyClipDrag()` (`apps/web/src/engine/timeline/drag.ts`) computed a clip's new start position from the raw pointer delta with no lower bound, then passed it straight to `moveEntityTo()`. Dragging a clip past the 0s mark produced a negative start (e.g. `-00:02`). The sibling trim path already clamps its edge via `trimBounds()`; the move/drag path was missing the equivalent floor.

## Fix
Clamp the computed start to `Math.max(0, ...)` in `applyClipDrag()`, matching the trim path's bound.

Fixes #55