### PR TITLE
fix: anchor CLI socket under homedir instead of tmpdir

### DIFF
--- a/apps/cli/src/cli-socket-path.ts
+++ b/apps/cli/src/cli-socket-path.ts
@@ -2,15 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { platform, tmpdir } from "node:os";
+import { homedir, platform } from "node:os";
 import { join } from "node:path";
 
-// One socket / named pipe per host. On macOS tmpdir is per-user; on Linux /tmp
-// is global but the socket file's owner-only mode 0600 keeps it isolated.
+// One socket / named pipe per host. Stays under the user's home — not
+// os.tmpdir() — because $TMPDIR differs between the two processes that talk
+// to each other: the app is launched by Finder/Dock (no $TMPDIR, so
+// os.tmpdir() falls back to /tmp) while the CLI runs in a terminal ($TMPDIR
+// set to /var/folders/.../T). Anchoring on homedir() gives both the same
+// path and keeps the socket owner-only (dir mode 0700) for isolation.
 //
 // Kept separate from cli-channels so the renderer can import the channel
 // registry and envelope types without pulling in node:os / node:path.
+export const SOCKET_DIR = join(homedir(), ".diffusion-studio");
 export const SOCKET_PATH =
   platform() === "win32"
     ? "\\\\.\\pipe\\diffusion-studio"
-    : join(tmpdir(), "diffusion-studio.sock");
+    : join(SOCKET_DIR, "diffusion-studio.sock");

--- a/apps/desktop/src/cli-server.ts
+++ b/apps/desktop/src/cli-server.ts
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { existsSync, unlinkSync } from "node:fs";
+import { existsSync, mkdirSync, unlinkSync } from "node:fs";
 import { createServer } from "node:net";
 import type { Server, Socket } from "node:net";
 import { app, BrowserWindow } from "electron";
-import { CLI_WIRE, SOCKET_PATH } from "@diffusionstudio/cli/protocol";
+import { CLI_WIRE, SOCKET_DIR, SOCKET_PATH } from "@diffusionstudio/cli/protocol";
 import type { CliHandshake, CliHandshakeReply } from "@diffusionstudio/cli/protocol";
 import { mainBridge } from "./main-manager";
 import { MAIN_CHANNELS } from "./main-channels";
@@ -102,6 +102,7 @@ async function deliverHandshake(handshake: CliHandshake, sock: Socket): Promise<
 
 export function startCliServer() {
   cleanupStaleSocket();
+  if (process.platform !== "win32") mkdirSync(SOCKET_DIR, { recursive: true, mode: 0o700 });
   bindWindowLifecycle();
 
   cliServer = createServer({ allowHalfOpen: true }, (sock: Socket) => {


### PR DESCRIPTION
## Bug
dapi always reports "not running" even when the app is up: app (Finder/Dock launch) gets no \$TMPDIR so os.tmpdir() falls back to /tmp, while dapi (terminal launch) inherits the shell's \$TMPDIR (/var/folders/.../T). Each computed a different socket path, so dapi's connect always hit ENOENT.

## Fix
Anchor the socket under `~/.diffusion-studio` (mode 0700) instead of `os.tmpdir()`, so both processes agree on the same path regardless of launch context.

Closes #60